### PR TITLE
abi-compliance-checker: Fix for Linuxbrew

### DIFF
--- a/Formula/abi-compliance-checker.rb
+++ b/Formula/abi-compliance-checker.rb
@@ -16,7 +16,7 @@ class AbiComplianceChecker < Formula
 
   def install
     system "perl", "Makefile.pl", "-install", "--prefix=#{prefix}"
-    rm bin/"abi-compliance-checker.cmd"
+    rm bin/"abi-compliance-checker.cmd" if OS.mac?
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

### Description

Only delete abi-compliance-checker.cmd on OS X, since it is only created if the OS has "win" in its name (i.e. Windows and Darwin).

Closes Linuxbrew/linuxbrew#1084