### PR TITLE
hardlink: Depends on attr for Linuxbrew

### DIFF
--- a/Formula/hardlink.rb
+++ b/Formula/hardlink.rb
@@ -15,6 +15,7 @@ class Hardlink < Formula
   depends_on "pkg-config" => :build
   depends_on "gnu-getopt"
   depends_on "pcre"
+  depends_on "attr" if OS.linux?
 
   def install
     system "make", "PREFIX=#{prefix}", "MANDIR=#{man}", "BINDIR=#{bin}", "install"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

### Description

`hardlink` depends on `attr` on Linux.
Closes Linuxbrew/linuxbrew#1085