### PR TITLE
libtiff: Disable jbigkit

### DIFF
--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -27,6 +27,7 @@ class Libtiff < Formula
                           "--prefix=#{prefix}",
                           "--without-x",
                           "--disable-lzma",
+                          "--disable-jbig",
                           "--with-jpeg-include-dir=#{jpeg}/include",
                           "--with-jpeg-lib-dir=#{jpeg}/lib"
     system "make", "install"


### PR DESCRIPTION
Bottle built on Ubuntu 14 depends on libjbig.so.0