### PR TITLE
fontconfig: Depends on bzip2 for Linuxbrew

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -28,6 +28,7 @@ class Fontconfig < Formula
 
   depends_on "pkg-config" => :build
   depends_on "freetype"
+  depends_on "bzip2" => :recommended unless OS.mac?
   depends_on "expat" unless OS.mac?
 
   # Reverts commit http://cgit.freedesktop.org/fontconfig/commit/?id=7a6622f25cdfab5ab775324bef1833b67109801b,


### PR DESCRIPTION
`fc-cache: error while loading shared libraries: libbz2.so.1.0`

```
==> /home/linuxbrew/.linuxbrew/Cellar/fontconfig/2.11.1_2/bin/fc-cache -frv
.
Last 150 lines from /home/linuxbrew/.linuxbrew/logs/fontconfig/01.fc-cache:
2016-04-29 17:28:35 +0000
/home/linuxbrew/.linuxbrew/Cellar/fontconfig/2.11.1_2/bin/fc-cache
-frv
/home/linuxbrew/.linuxbrew/Cellar/fontconfig/2.11.1_2/bin/fc-cache: error while loading shared libraries: libbz2.so.1.0: cannot open shared object file: No such file or directory
Warning: The post-install step did not complete successfully
You can try again using `brew postinstall fontconfig`
==> Summary
/home/linuxbrew/.linuxbrew/Cellar/fontconfig/2.11.1_2: 451 files, 3M, built in 18 seconds
==> FAILED
```