### PR TITLE
webp: Depends on libtiff for Linuxbrew

### DIFF
--- a/Formula/webp.rb
+++ b/Formula/webp.rb
@@ -23,7 +23,7 @@ class Webp < Formula
 
   depends_on "libpng"
   depends_on "jpeg" => :recommended
-  depends_on "libtiff" => :optional
+  depends_on "libtiff" => (OS.mac? ? :optional : :recommended)
   depends_on "giflib" => :optional
 
   def install


### PR DESCRIPTION
The bottle built on Ubuntu 14 depends on libtiff.

`cwebp: error while loading shared libraries: libtiff.so.5`
https://travis-ci.org/Linuxbrew/homebrew-core/builds/126722930#L1139