### PR TITLE
readline: Bump revision for ncurses 6.0 for Linux

### DIFF
--- a/Formula/readline.rb
+++ b/Formula/readline.rb
@@ -5,6 +5,7 @@ class Readline < Formula
   mirror "https://ftp.gnu.org/gnu/readline/readline-6.3.tar.gz"
   version "6.3.8"
   sha256 "56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43"
+  revision 1 if OS.linux?
 
   bottle do
     cellar :any

--- a/Formula/readline.rb
+++ b/Formula/readline.rb
@@ -65,7 +65,8 @@ class Readline < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-lreadline", "-o", "test"
-    assert_equal "Hello, World!", pipe_output("./test", "Hello, World!\n").strip
+    system ENV.cc, "-L", lib, "test.c", "-lreadline", "-o", "test"
+    assert_equal "test> Hello, World!\nHello, World!",
+      pipe_output("./test", "Hello, World!\n").strip
   end
 end


### PR DESCRIPTION
The current bottle is linked against libncursesw.so.5