### PR TITLE
premake: Fix for Linuxbrew

### DIFF
--- a/Formula/premake.rb
+++ b/Formula/premake.rb
@@ -22,7 +22,7 @@ class Premake < Formula
       # Linking against stdc++-static causes a library not found error on 10.7
       inreplace "build/gmake.macosx/Premake4.make", "-lstdc++-static ", ""
     end
-    system "make", "-C", "build/gmake.macosx"
+    system "make", "-C", "build/gmake.#{OS.mac? ? "macosx" : "unix"}"
 
     # Premake has no install target, but its just a single file that is needed
     bin.install "bin/release/premake4"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

### Description

premake was using a Mac-specific Makefile.

Closes Linuxbrew/homebrew-core#71.

### Note

Doesn't pass `brew audit --strict` because there's no test.