### PR TITLE
mongoose: Fix for Linuxbrew.

### DIFF
--- a/Formula/mongoose.rb
+++ b/Formula/mongoose.rb
@@ -27,9 +27,15 @@ class Mongoose < Formula
       bin.install "web_server" => "mongoose"
     end
 
-    system ENV.cc, "-dynamiclib", "mongoose.c", "-o", "libmongoose.dylib"
+    if OS.mac?
+      system ENV.cc, "-dynamiclib", "mongoose.c", "-o", "libmongoose.dylib"
+      lib.install "libmongoose.dylib"
+    else
+      system ENV.cc, "-fPIC", "-c", "mongoose.c"
+      system ENV.cc, "-shared", "-Wl,-soname,libmongoose.so", "-o", "libmongoose.so", "mongoose.o", "-lc", "-lpthread"
+      lib.install "libmongoose.so"
+    end
     include.install "mongoose.h"
-    lib.install "libmongoose.dylib"
     pkgshare.install "examples", "jni"
     doc.install Dir["docs/*"]
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

### Description

mongoose was using Apple-only GCC flags and shared library naming
conventions.

Closes Linuxbrew/homebrew-core#79.