### PR TITLE
glib: disable selinux support.

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -3,6 +3,7 @@ class Glib < Formula
   homepage "https://developer.gnome.org/glib/"
   url "https://download.gnome.org/sources/glib/2.46/glib-2.46.2.tar.xz"
   sha256 "5031722e37036719c1a09163cc6cf7c326e4c4f1f1e074b433c156862bd733db"
+  revision 1 if OS.linux?
 
   bottle do
     sha256 "7712b8d7682c79d31f8325e4a6a99d43ed480907420193035ba4a874603d720e" => :el_capitan
@@ -85,6 +86,7 @@ class Glib < Formula
       --disable-silent-rules
       --disable-dtrace
       --disable-libelf
+      --disable-selinux
       --enable-static
       --prefix=#{prefix}
       --localstatedir=#{var}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

### Description
This PR disables SELinux support for `glib`. We already do this for some other formulae, including `glibc` and `gnu-sed`.

This is needed for gobject-introspection to build correctly.

Closes Linuxbrew/homebrew-core#98.