### PR TITLE
global: Depends on ncurses for Linuxbrew.

### DIFF
--- a/Formula/global.rb
+++ b/Formula/global.rb
@@ -26,6 +26,7 @@ class Global < Formula
   deprecated_option "with-exuberant-ctags" => "with-ctags"
 
   depends_on "ctags" => :optional
+  depends_on "homebrew/dupes/ncurses" unless OS.mac?
 
   skip_clean "lib/gtags"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

### Description
`global` needs to depend on `homebrew/dupes/ncurses` on non-Mac.

### Note
Fails strict audit, but not due to my changes.