### PR TITLE
openssl: depends on perl for Linuxbrew.

### DIFF
--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -5,6 +5,7 @@ class Openssl < Formula
   mirror "https://dl.bintray.com/homebrew/mirror/openssl-1.0.2h.tar.gz"
   mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-1.0.2h.tar.gz"
   sha256 "1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919"
+  revision 1 # remove this before merging
 
   bottle do
     sha256 "28320f60a208f1aba5420957148458d59b00bcac62fcb550ba88e737c07c27b4" => :el_capitan
@@ -29,6 +30,7 @@ class Openssl < Formula
 
   depends_on "makedepend" => :build
   depends_on "zlib" unless OS.mac?
+  depends_on :perl => ["5.0", :build] unless OS.mac?
 
   def arch_args
     return { :i386  => %w[linux-generic32], :x86_64 => %w[linux-x86_64] } if OS.linux?


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

```
BuildError: Failed executing: perl ./Configure --prefix=/home/linuxbrew/.linuxbrew/Cellar/openssl/1.0.2h --openssldir=/home/linuxbrew/.linuxbrew/etc/openssl no-ssl2 zlib-dynamic shared enable-cms -isystem/home/linuxbrew/.linuxbrew/include\ -Os\ -w\ -pipe\ -march=core2\ -L/home/linuxbrew/.linuxbrew/lib\ -Wl,--dynamic-linker=/home/linuxbrew/.linuxbrew/lib/ld.so\ -Wl,-rpath,/home/linuxbrew/.linuxbrew/lib linux-x86_64
```