### PR TITLE
ffmpeg: Depends on bzip2 for Linuxbrew

### DIFF
--- a/Formula/ffmpeg.rb
+++ b/Formula/ffmpeg.rb
@@ -47,6 +47,7 @@ class Ffmpeg < Formula
   depends_on "x264" => :recommended
   depends_on "lame" => :recommended
   depends_on "xvid" => :recommended
+  depends_on "bzip2" unless OS.mac?
   depends_on "xz" => :recommended unless OS.mac?
 
   depends_on "faac" => :optional


### PR DESCRIPTION
Fix ffmpeg: error while loading shared libraries: libbz2.so.1.0