### PR TITLE
ghc: Do not hardcode compiler path for Linxubrew

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -105,10 +105,10 @@ class Ghc < Formula
     args = ["--with-gmp-includes=#{gmp}/include",
             "--with-gmp-libraries=#{gmp}/lib",
             "--with-ld=ld", # Avoid hardcoding superenv's ld.
-            "--with-gcc=#{ENV.cc}"] # Always.
+            "--with-gcc=#{OS.mac? ? ENV.cc : "gcc"}"] # Always.
 
     if ENV.compiler == :clang
-      args << "--with-clang=#{ENV.cc}"
+      args << "--with-clang=#{OS.mac? ? ENV.cc : "clang"}"
     elsif ENV.compiler == :llvm
       args << "--with-gcc-4.2=#{ENV.cc}"
     end

--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -166,5 +166,7 @@ class Ghc < Formula
   test do
     (testpath/"hello.hs").write('main = putStrLn "Hello Homebrew"')
     system "#{bin}/runghc", testpath/"hello.hs"
+    system "#{bin}/ghc", "-o", "hello", "hello.hs"
+    system "./hello"
   end
 end


### PR DESCRIPTION
Fix error: ghc: could not execute: /usr/bin/gcc-4.8