### PR TITLE
libxml2: Depends on zlib :recommended for Linuxbrew

### DIFF
--- a/Formula/libxml2.rb
+++ b/Formula/libxml2.rb
@@ -4,6 +4,7 @@ class Libxml2 < Formula
   url "http://xmlsoft.org/sources/libxml2-2.9.3.tar.gz"
   mirror "ftp://xmlsoft.org/libxml2/libxml2-2.9.3.tar.gz"
   sha256 "4de9e31f46b44d34871c22f54bfc54398ef124d6f7cafb1f4a5958fbcd3ba12d"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any
@@ -22,6 +23,7 @@ class Libxml2 < Formula
   end
 
   depends_on :python => :optional
+  depends_on "zlib" => :recommended unless OS.mac?
 
   keg_only :provided_by_osx
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

Fails strict audit due to bad location of `option` vs. `depends_on`. Will try and fix that upstream.

Based on discovery [here](https://github.com/Linuxbrew/homebrew-xorg/pull/94#issuecomment-220325174) that `libxml2` should ideally depend on `zlib` for the benefit of `libxslt`.