### PR TITLE
gnu-getopt: make keg-only on Linux

### DIFF
--- a/Formula/gnu-getopt.rb
+++ b/Formula/gnu-getopt.rb
@@ -11,7 +11,7 @@ class GnuGetopt < Formula
     sha256 "88a02cd609a91253e9b996a1fcb1e8837161673e413fe792e5d05aa3ff9a94cf" => :mountain_lion
   end
 
-  keg_only :provided_by_osx
+  keg_only (OS.mac? ? :provided_by_osx : "This formula conflicts with util-linux")
 
   depends_on "gettext"
 


### PR DESCRIPTION
FYI @maxim-belkin 

Fixes #144 
