### PR TITLE
systemd: depend on coreutils on Linux to enable `--relative` flag for `ln` command

### DIFF
--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -16,6 +16,7 @@ class Systemd < Formula
   depends_on "libcap"
   depends_on "pkg-config" => :build
   depends_on "util-linux" # for libmount
+  depends_on "coreutils" => :build
   depends_on "XML::Parser" => :perl
 
   def install


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----
On Linux distros with old `coreutils` package the `ln` command does not accept `--relative` flag, hence installation fails with:
```
configure: error: *** ln doesn't support --relative ***
```
The proposed fix adds a dependency on `coreutils` that solves the problem.
