### PR TITLE
moc:  undefined reference to `__clock_getres@GLIBC_PRIVATE'

### DIFF
--- a/Formula/moc.rb
+++ b/Formula/moc.rb
@@ -1,3 +1,4 @@
+# moc: Build a bottle for Linuxbrew
 class Moc < Formula
   desc "Terminal-based music player"
   homepage "https://moc.daper.net"


### PR DESCRIPTION
See #317 and #344 
