### PR TITLE
consul: build only for current platform

### DIFF
--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -186,7 +186,7 @@ class Consul < Formula
     Language::Go.stage_deps resources, gopath/"src"
 
     cd gopath/"src/github.com/hashicorp/consul" do
-      system "make"
+      system "make", "dev"
       bin.install "bin/consul"
       zsh_completion.install "contrib/zsh-completion/_consul"
     end

--- a/Formula/consul.rb
+++ b/Formula/consul.rb
@@ -203,7 +203,7 @@ class Consul < Formula
 
   test do
     fork do
-      exec "#{bin}/consul", "agent", "-data-dir", "."
+      exec "#{bin}/consul", "agent", "-data-dir", ".", "-bind", "127.0.0.1"
     end
     sleep 3
     system "#{bin}/consul", "leave"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

`make dev` means building only for the current architecture as opposed to building every possible binary for every supported platform.

It may also help with:

```
make
--> Installing build dependencies
--> Running go fmt
==> Getting dependencies...
==> Removing old directory...
==> Building...
Number of parallel builds: 3

-->   freebsd/amd64: github.com/hashicorp/consul
-->   windows/amd64: github.com/hashicorp/consul
-->     linux/amd64: github.com/hashicorp/consul
-->       linux/arm: github.com/hashicorp/consul
-->    darwin/amd64: github.com/hashicorp/consul
-->   solaris/amd64: github.com/hashicorp/consul
-->      darwin/386: github.com/hashicorp/consul
-->      darwin/arm: github.com/hashicorp/consul
-->     freebsd/386: github.com/hashicorp/consul
-->     windows/386: github.com/hashicorp/consul
-->     freebsd/arm: github.com/hashicorp/consul
-->       linux/386: github.com/hashicorp/consul

1 errors occurred:
--> darwin/arm error: exit status 2
Stderr: # github.com/hashicorp/consul
link: warning: option -X main.GitCommit c933efde50d25395c7b5a42167578fda603d43d8+CHANGES may not work in future releases; use -X main.GitCommit=c933efde50d25395c7b5a42167578fda60
3d43d8+CHANGES
link: warning: option -X main.GitDescribe v0.6.3 may not work in future releases; use -X main.GitDescribe=v0.6.3
runtime.load_g: call to external function runtime.read_tls_fallback
runtime._initcgo: call to external function runtime.read_tls_fallback
runtime.save_g: runtime.read_tls_fallback: not defined
runtime.load_g: runtime.read_tls_fallback: not defined
runtime._initcgo: runtime.read_tls_fallback: not defined
runtime.save_g: undefined: runtime.read_tls_fallback
runtime.load_g: undefined: runtime.read_tls_fallback
runtime._initcgo: undefined: runtime.read_tls_fallback

make: *** [all] Error 1
```