### PR TITLE
patchelf: Fix cannot find section

### DIFF
--- a/Formula/patchelf.rb
+++ b/Formula/patchelf.rb
@@ -5,6 +5,7 @@ class Patchelf < Formula
 
   url "http://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.gz"
   sha256 "f2aa40a6148cb3b0ca807a1bf836b081793e55ec9e5540a5356d800132be7e0a"
+  revision 1
 
   bottle do
     cellar :any
@@ -21,6 +22,11 @@ class Patchelf < Formula
   option "without-static-libstdc++", "Link libstdc++ dynamically"
 
   def install
+    # Fixes error: cannot find section
+    # See https://github.com/NixOS/patchelf/pull/95
+    inreplace "src/patchelf.cc",
+      "string sectionName = getSectionName(shdr);",
+      'string sectionName = getSectionName(shdr); if (sectionName == "") continue;'
     system "./bootstrap.sh" if build.head?
     system "./configure", "--prefix=#{prefix}",
       if build.with?("static") then "CXXFLAGS=-static"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

Fixes problems with `go` static executables, such as those in #149 or #351 . Upstream PR: https://github.com/NixOS/patchelf/pull/95