### PR TITLE
libunwind: Fix audit

### DIFF
--- a/Formula/libunwind.rb
+++ b/Formula/libunwind.rb
@@ -1,8 +1,10 @@
 class Libunwind < Formula
+  desc "C API for determining the call-chain of a program"
   homepage "http://www.nongnu.org/libunwind/"
   url "http://download.savannah.gnu.org/releases/libunwind/libunwind-1.1.tar.gz"
   sha256 "9dfe0fcae2a866de9d3942c66995e4b460230446887dbdab302d41a8aee8d09a"
   head "git://git.sv.gnu.org/libunwind.git"
+  # tag "linuxbrew"
 
   def install
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
`libunwind` isn't available upstream, so tagging it as Linux-only.