### PR TITLE
abi-compliance-checker: Fix test for Linuxbrew

### DIFF
--- a/Formula/abi-compliance-checker.rb
+++ b/Formula/abi-compliance-checker.rb
@@ -26,7 +26,7 @@ class AbiComplianceChecker < Formula
       <headers>#{Formula["ctags"].include}</headers>
       <libs>#{Formula["ctags"].lib}</libs>
     EOS
-    gcc_suffix = Formula["gcc"].version.to_s.slice(/\d\.\d+/)
+    gcc_suffix = Formula["gcc"].version.to_s.slice(OS.mac? ? /\d\.\d+/ : /\d/)
     system bin/"abi-compliance-checker", "-cross-gcc", "gcc-" + gcc_suffix,
                                          "-lib", "ctags",
                                          "-old", testpath/"test.xml",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

On Linuxbrew, the gcc formula installs gcc-5 and gcc executables, but not a gcc-5.3 executable. We therefore change the regexp used to determine the gcc suffix since the actual version of the formula is  5.3.

Closes Linuxbrew/homebrew-core#25.