### PR TITLE
pcre2: Depends on bzip2 for Linuxbrew

### DIFF
--- a/Formula/pcre2.rb
+++ b/Formula/pcre2.rb
@@ -17,6 +17,8 @@ class Pcre2 < Formula
 
   option :universal
 
+  depends_on "bzip2" unless OS.mac?
+
   def install
     ENV.universal_binary if build.universal?
 


### PR DESCRIPTION
Fix error: Cannot --enable-pcre2grep-libbz2 because libbz2 was not found

Fixes Linuxbrew/homebrew-core#422