### PR TITLE
ansible: depends on krb5 for Linuxbrew

### DIFF
--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -233,6 +233,12 @@ class Ansible < Formula
     sha256 "12dff9afa9c6cd6e2a39960d3cd4b46b2b98768cdc6646833c66b20799c1c58e"
   end
 
+  # needed by pbr, needed in turn by debtcollector
+  resource "pytz" do
+    url "https://pypi.python.org/packages/source/p/pytz/pytz-2016.3.tar.bz2"
+    sha256 "c193dfa167ac32c8cb96f26cbcd92972591b22bda0bac3effdbdb04de6cc55d6"
+  end
+
   resource "debtcollector" do
     url "https://pypi.python.org/packages/source/d/debtcollector/debtcollector-1.3.0.tar.gz"
     sha256 "9a65cf09239eab75b961ef609b3176ed2487bedcfa0a465331661824e1c8db8f"
@@ -357,11 +363,6 @@ class Ansible < Formula
   resource "python-novaclient" do
     url "https://pypi.python.org/packages/source/p/python-novaclient/python-novaclient-2.27.0.tar.gz"
     sha256 "d1279d5c2857cf8c56cb953639b36225bc1fec7fa30ee632940823506a7638ef"
-  end
-
-  resource "pytz" do
-    url "https://pypi.python.org/packages/source/p/pytz/pytz-2016.3.tar.bz2"
-    sha256 "c193dfa167ac32c8cb96f26cbcd92972591b22bda0bac3effdbdb04de6cc55d6"
   end
 
   resource "rackspace-auth-openstack" do

--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -23,6 +23,8 @@ class Ansible < Formula
   depends_on "libyaml"
   depends_on "openssl"
   depends_on "libffi" unless OS.mac?
+  depends_on "homebrew/dupes/krb5" unless OS.mac?
+  depends_on "libxslt" unless OS.mac?
 
   #
   # ansible (core dependencies)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

Error log:

```
Last 15 lines from /home/doomhammer/.cache/Homebrew/Logs/ansible/26.python:
creating build/temp.linux-x86_64-2.7
creating build/temp.linux-x86_64-2.7/src
/home/doomhammer/.linuxbrew/bin/gcc-5 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -Os -w -pipe -march=native -isystem/home/doomhammer/.linuxbrew/include -fPIC -I/home/doomhammer/.linuxbrew/include -I/home/doomhammer/.linuxbrew/opt/openssl/include -I/home/doomhammer/.linuxbrew/opt/sqlite/include -I/home/doomhammer/.linuxbrew/Cellar/python/2.7.11/include/python2.7 -c src/base64.c -o build/temp.linux-x86_64-2.7/src/base64.o
/home/doomhammer/.linuxbrew/bin/gcc-5 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -Os -w -pipe -march=native -isystem/home/doomhammer/.linuxbrew/include -fPIC -I/home/doomhammer/.linuxbrew/include -I/home/doomhammer/.linuxbrew/opt/openssl/include -I/home/doomhammer/.linuxbrew/opt/sqlite/include -I/home/doomhammer/.linuxbrew/Cellar/python/2.7.11/include/python2.7 -c src/kerberos.c -o build/temp.linux-x86_64-2.7/src/kerberos.o
/home/doomhammer/.linuxbrew/bin/gcc-5 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -Os -w -pipe -march=native -isystem/home/doomhammer/.linuxbrew/include -fPIC -I/home/doomhammer/.linuxbrew/include -I/home/doomhammer/.linuxbrew/opt/openssl/include -I/home/doomhammer/.linuxbrew/opt/sqlite/include -I/home/doomhammer/.linuxbrew/Cellar/python/2.7.11/include/python2.7 -c src/kerberosbasic.c -o build/temp.linux-x86_64-2.7/src/kerberosbasic.o
/home/doomhammer/.linuxbrew/bin/gcc-5 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -Os -w -pipe -march=native -isystem/home/doomhammer/.linuxbrew/include -fPIC -I/home/doomhammer/.linuxbrew/include -I/home/doomhammer/.linuxbrew/opt/openssl/include -I/home/doomhammer/.linuxbrew/opt/sqlite/include -I/home/doomhammer/.linuxbrew/Cellar/python/2.7.11/include/python2.7 -c src/kerberosgss.c -o build/temp.linux-x86_64-2.7/src/kerberosgss.o
/home/doomhammer/.linuxbrew/bin/gcc-5 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -Os -w -pipe -march=native -isystem/home/doomhammer/.linuxbrew/include -fPIC -I/home/doomhammer/.linuxbrew/include -I/home/doomhammer/.linuxbrew/opt/openssl/include -I/home/doomhammer/.linuxbrew/opt/sqlite/include -I/home/doomhammer/.linuxbrew/Cellar/python/2.7.11/include/python2.7 -c src/kerberospw.c -o build/temp.linux-x86_64-2.7/src/kerberospw.o
creating build/lib.linux-x86_64-2.7
/home/doomhammer/.linuxbrew/bin/gcc-5 -pthread -shared -L/home/doomhammer/.linuxbrew/lib -Wl,--dynamic-linker=/home/doomhammer/.linuxbrew/lib/ld.so -Wl,-rpath,/home/doomhammer/.linuxbrew/lib -L/home/doomhammer/.linuxbrew/lib -Wl,--dynamic-linker=/home/doomhammer/.linuxbrew/lib/ld.so -Wl,-rpath,/home/doomhammer/.linuxbrew/lib -Os -w -pipe -march=native -isystem/home/doomhammer/.linuxbrew/include build/temp.linux-x86_64-2.7/src/base64.o build/temp.linux-x86_64-2.7/src/kerberos.o build/temp.linux-x86_64-2.7/src/kerberosbasic.o build/temp.linux-x86_64-2.7/src/kerberosgss.o build/temp.linux-x86_64-2.7/src/kerberospw.o -L/home/doomhammer/.linuxbrew/lib -L/home/doomhammer/.linuxbrew/opt/openssl/lib -L/home/doomhammer/.linuxbrew/opt/sqlite/lib -L/home/doomhammer/.linuxbrew/Cellar/python/2.7.11/lib -lpython2.7 -o build/lib.linux-x86_64-2.7/kerberos.so -Wl,-Bsymbolic-functions -Wl,-z,relro -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err
/home/doomhammer/.linuxbrew/bin/ld: cannot find -lgssapi_krb5
/home/doomhammer/.linuxbrew/bin/ld: cannot find -lkrb5
/home/doomhammer/.linuxbrew/bin/ld: cannot find -lk5crypto
/home/doomhammer/.linuxbrew/bin/ld: cannot find -lcom_err
collect2: error: ld returned 1 exit status
error: command '/home/doomhammer/.linuxbrew/bin/gcc-5' failed with exit status 1
```