### PR TITLE
gtk: Temporarily disable linking against cups

### DIFF
--- a/Formula/gtk+.rb
+++ b/Formula/gtk+.rb
@@ -61,6 +61,9 @@ class Gtkx < Formula
 
     args << "--enable-quartz-relocation" if build.with?("quartz-relocation")
 
+    # temporarily disable cups until linuxbrew/homebrew-core#495 is merged
+    args << "--disable-cups" unless OS.mac?
+
     if build.head?
       inreplace "autogen.sh", "libtoolize", "glibtoolize"
       ENV["NOCONFIGURE"] = "yes"
@@ -121,10 +124,10 @@ class Gtkx < Formula
       -lglib-2.0
       -lgobject-2.0
       -lgtk-#{backend}-2.0
-      -lintl
       -lpango-1.0
       -lpangocairo-1.0
     ]
+    flags << "-lintl" if OS.mac?
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

Fixes error: Sorry, cups-config present but cups/cups.h missing.

Also, fix the test.

#495 might take a while to get all the permission things right, so in the meantime I'm fixing the GTK+ build by disabling CUPS. Not a perfect solution, but it will unblock a huge number of other formulae.

The audit failures were already there; I suspect they have already been fixed upstream.