### PR TITLE
gcc: Fix build error in libgomp when glibc is installed

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -84,6 +84,11 @@ class Gcc < Formula
   patch :DATA if OS.mac?
 
   def install
+    if OS.linux?
+      # libgomp does not respect LDFLAGS, configure fails when
+      # glibc is installed.
+      ENV.append "CFLAGS", "-Wl,--dynamic-linker=#{HOMEBREW_PREFIX}/lib/ld.so -Wl,-rpath,#{HOMEBREW_PREFIX}/lib"
+    end
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

---

When glibc is installed, programs need to be linked with options that specify settings for the dynamic linker and rpath, via the LDFLAGS environment variable.

The special compilation line used by one of the probes in libgomp's autoconf generated configure script doesn't deal with LDFLAGS appropriately, but [also] setting CFLAGS seems to work.

See issue https://github.com/Linuxbrew/homebrew-science/issues/257
