### PR TITLE
openssl: fix error: target already defined

### DIFF
--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -48,7 +48,7 @@ class Openssl < Formula
     zlib-dynamic
     shared
     enable-cms
-    #{[ENV.cppflags, ENV.cflags, ENV.ldflags].join(" ") unless OS.mac?}
+    #{[ENV.cppflags, ENV.cflags, ENV.ldflags].join(" ").strip unless OS.mac?}
   ]
   end
 


### PR DESCRIPTION
Fixes issue #350 by trimming leading and trailing space from option string formed by joining cppflags, cflags and ldflags.