### PR TITLE
openssl: skip check if cmp unavailable

### DIFF
--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -89,7 +89,11 @@ class Openssl < Formula
       system "perl", "./Configure", *(configure_args + arch_args[arch])
       system "make", "depend"
       system "make"
-      system "make", "test" if build.with?("test")
+      if which "cmp"
+        system "make", "test" if build.with?("test")
+      else
+        opoo "Skipping `make check` due to unavailable `cmp`"
+      end
 
       if build.universal?
         cp "include/openssl/opensslconf.h", dir


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

To prevent:

```
Last 15 lines from /home/doomhammer/.cache/Homebrew/Logs/openssl/04.make:
Testing key generation with NIST Binary-Curve B-233 .... ok
Testing key generation with NIST Binary-Curve K-283 .... ok
Testing key generation with NIST Binary-Curve B-283 .... ok
Testing key generation with NIST Binary-Curve K-409 .... ok
Testing key generation with NIST Binary-Curve B-409 .... ok
Testing key generation with NIST Binary-Curve K-571 .... ok
Testing key generation with NIST Binary-Curve B-571 .... ok
Testing ECDH shared secret with Brainpool Prime-Curve brainpoolP256r1 ok
Testing ECDH shared secret with Brainpool Prime-Curve brainpoolP384r1 ok
Testing ECDH shared secret with Brainpool Prime-Curve brainpoolP512r1 ok
cat
./testenc: 12: ./testenc: cmp: not found
make[1]: *** [test_enc] Error 1
make[1]: Leaving directory `/tmp/openssl-20160724-32360-nw7na4/openssl-1.0.2h/test'
make: *** [tests] Error 2
```