### PR TITLE
pango: Depends on x11 for Linuxbrew

### DIFF
--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -93,10 +93,10 @@ class Pango < Formula
       -lcairo
       -lglib-2.0
       -lgobject-2.0
-      -lintl
       -lpango-1.0
       -lpangocairo-1.0
     ]
+    flags << "-lintl" if OS.mac?
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end

--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -27,6 +27,7 @@ class Pango < Formula
   depends_on "harfbuzz"
   depends_on "fontconfig"
   depends_on "gobject-introspection"
+  depends_on :x11 unless OS.mac?
 
   fails_with :llvm do
     build 2326


### PR DESCRIPTION
```
Package xcb-shm was not found in the pkg-config search path.
Perhaps you should add the directory containing `xcb-shm.pc'
to the PKG_CONFIG_PATH environment variable
Package 'xcb-shm', required by 'cairo', not found
```