### PR TITLE
pulseaudio: Fix for Linuxbrew

### DIFF
--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -22,6 +22,7 @@ class Pulseaudio < Formula
   option :universal
 
   depends_on "pkg-config" => :build
+  depends_on "homebrew/dupes/m4" => :build unless OS.mac?
 
   if build.with? "nls"
     depends_on "intltool" => :build
@@ -33,6 +34,7 @@ class Pulseaudio < Formula
   depends_on "libsndfile"
   depends_on "libsoxr"
   depends_on "openssl"
+  depends_on "libcap" unless OS.mac?
 
   depends_on :x11 => :optional
   depends_on "glib" => :optional
@@ -57,7 +59,6 @@ class Pulseaudio < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
-      --enable-coreaudio-output
       --disable-neon-opt
       --with-mac-sysroot=/
     ]
@@ -65,6 +66,7 @@ class Pulseaudio < Formula
     args << "--with-mac-sysroot=#{MacOS.sdk_path}"
     args << "--with-mac-version-min=#{MacOS.version}"
     args << "--disable-nls" if build.without? "nls"
+    args << "--enable-coreaudio-output" if OS.mac?
 
     if build.universal?
       args << "--enable-mac-universal"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

Don't build against the macOS-only CoreAudio system.
Also, it depends on homebrew/dupes/m4 and libcaps.

Fix errors:
* configure: error: m4 missing
* configure: error: *** sys/capability.h not found.
    Use --without-caps to disable capabilities support.
* configure: error: *** CoreAudio output support not found

Note: we *might* run into https://github.com/Homebrew/homebrew-core/issues/2408