### PR TITLE
depqbf: Fix for Linuxbrew

### DIFF
--- a/Formula/depqbf.rb
+++ b/Formula/depqbf.rb
@@ -16,7 +16,7 @@ class Depqbf < Formula
   def install
     system "make"
     bin.install "depqbf"
-    lib.install "libqdpll.1.0.dylib"
+    lib.install "libqdpll.#{OS.mac? ? "1.0.dylib" : "so.1.0"}"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

Fixes error: `Error: No such file or directory - libqdpll.1.0.dylib`

Note online audit failure: GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars). This is beyond my control.