### PR TITLE
glibc25: Use SHA-256 instead of SHA-1

### DIFF
--- a/Formula/glibc25.rb
+++ b/Formula/glibc25.rb
@@ -3,7 +3,7 @@ require "formula"
 class Glibc25 < Formula
   homepage "http://www.gnu.org/software/libc/download.html"
   url "http://ftpmirror.gnu.org/glibc/glibc-2.5.1.tar.bz2"
-  sha1 "2b7da136df025bb8c787be3351cba58374226d9c"
+  sha256 "a29e0d149816364820512f71b9c9ebd0f8a148fbeaac42b79e2c342532e5bf8e"
 
   conflicts_with "glibc", :because => "both install libc.so.6"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

This changes `glibc25` to use a SHA-256 sum rather than SHA-1, as it is now deprecated and throws errors on every Travis/Circle run as a result.

3 other formulae do this too, but they come from upstream and so should probably be fixed on the next merge.

Note that this formula does not pass a strict audit, but there's too much to fix at the moment.