### PR TITLE
samba: Fix for Linuxbrew

### DIFF
--- a/Formula/samba.rb
+++ b/Formula/samba.rb
@@ -43,7 +43,7 @@ class Samba < Formula
       # https://bugzilla.samba.org/show_bug.cgi?id=11113
       inreplace "Makefile" do |s|
         s.gsub! /(lib\w+).dylib(.[\.\d]+)/, "\\1\\2.dylib"
-      end
+      end if OS.mac?
 
       (prefix/"private").mkpath
       (prefix/"var/locks").mkpath


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

Fix error: 
```
Error: inreplace failed
Makefile:
  expected replacement of /(lib\w+).dylib(.[\.\d]+)/ with "\\1\\2.dylib"
```

There's an audit failure, but it needs to be fixed upstream.