### PR TITLE
glibc: fix zoneinfo by installing system version

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -64,6 +64,11 @@ class Glibc < Formula
     sys_localtime = Pathname.new "/etc/localtime"
     brew_localtime = Pathname.new prefix/"etc/localtime"
     (prefix/"etc").install_symlink sys_localtime if sys_localtime.exist? && !brew_localtime.exist?
+
+    # Set zoneinfo correctly using the system installed zoneinfo
+    sys_zoneinfo = Pathname.new "/usr/share/zoneinfo"
+    brew_zoneinfo = Pathname.new prefix/"share/zoneinfo"
+    (prefix/"share").install_symlink sys_zoneinfo if sys_zoneinfo.exist? && !brew_zoneinfo.exist?
   end
 
   test do

--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -67,8 +67,8 @@ class Glibc < Formula
 
     # Set zoneinfo correctly using the system installed zoneinfo
     sys_zoneinfo = Pathname.new "/usr/share/zoneinfo"
-    brew_zoneinfo = Pathname.new prefix/"share/zoneinfo"
-    (prefix/"share").install_symlink sys_zoneinfo if sys_zoneinfo.exist? && !brew_zoneinfo.exist?
+    brew_zoneinfo = Pathname.new share/"zoneinfo"
+    share.install_symlink sys_zoneinfo if sys_zoneinfo.exist? && !brew_zoneinfo.exist?
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

Some steps above were not followed to the letter due to issues in reinstalling (I can't get glibc to reinstall due to missing gcc-5 issues) also brew audit strict failed because `* C: 24: col 14: Closing array brace must be on the line after the last array element when opening brace is on a separate line from the first array element.`. This isn't related to my commit so I'm skipping this as something for me to fix.

-----

Solves a problem referenced in Linuxbrew/brew#92 where `strftime` did not understand timezones such as `Australia/Darwin`. The formula now creates a symbolic link in the installed glibc's share directory to a system installed copy of the zoneinfo. If the system has not installed zoneinfo in the default location then we do not do link anything in. A user would have to do this step manually.