### PR TITLE
util-linux: Prevent conflict with bsdmainutils

### DIFF
--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -3,6 +3,7 @@ class UtilLinux < Formula
   homepage "https://github.com/karelzak/util-linux"
   url "https://www.kernel.org/pub/linux/utils/util-linux/v2.27/util-linux-2.27.1.tar.xz"
   sha256 "0a818fcdede99aec43ffe6ca5b5388bff80d162f2f7bd4541dca94fecb87a290"
+  revision 1
   head "https://github.com/karelzak/util-linux.git"
   # tag "linuxbrew"
 
@@ -12,18 +13,38 @@ class UtilLinux < Formula
 
   def install
     system "./configure",
-      "--disable-debug",
       "--disable-dependency-tracking",
       "--disable-silent-rules",
       "--prefix=#{prefix}",
       # Fix chgrp: changing group of 'wall': Operation not permitted
       "--disable-use-tty-group",
       # Conflicts with coreutils.
-      "--disable-kill"
+      "--disable-kill",
+      # Conflicts with bsdmainutils
+      "--disable-cal",
+      "--disable-ul"
     system "make", "install"
+
+    # Conflicts with bsdmainutils and cannot be manually disabled
+    conflicts = %w[
+      col*
+      hexdump*
+      look*
+    ]
+    conflicts.each do |conflict|
+      rm_f Dir.glob("{#{bin},#{man1}}/#{conflict}")
+    end
+  end
+
+  def caveats; <<-EOS.undent
+    Some commands were moved to the bsdmainutils formula.
+    You may wish to install it as well.
+    EOS
   end
 
   test do
-    assert_match "January", shell_output("#{bin}/cal 1 2016")
+    (testpath/"tmpfile").write("temp")
+    system bin/"rename", "tmp", "temp", testpath/"tmpfile"
+    assert File.exist?(testpath/"tempfile")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --strict --online <formula>` (after doing `brew install <formula>`)?

-----

Split off from #757. Drops a number of the `util-linux` binaries in favour of those from `bsdmainutils`, conforming to how Debian/Ubuntu handle the duplication.