### PR TITLE
jsdoc-toolkit: Fix for Linuxbrew

### DIFF
--- a/Formula/jsdoc-toolkit.rb
+++ b/Formula/jsdoc-toolkit.rb
@@ -10,7 +10,8 @@ class JsdocToolkit < Formula
 
   def install
     system "/bin/echo '#!/bin/ksh\nJSDOCDIR=\"#{libexec}/jsdoc-toolkit\"' > jsdoc"
-    system "/usr/bin/grep -v \"^echo \\$CMD$\" jsdoc-toolkit/jsrun.sh >> jsdoc"
+    grep = File.executable?("/usr/bin/grep") ? "/usr/bin/grep" : "/bin/grep"
+    system "#{grep} -v \"^echo \\$CMD$\" jsdoc-toolkit/jsrun.sh >> jsdoc"
 
     bin.install "jsdoc"
     libexec.install "jsdoc-toolkit"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

/usr/bin/grep does not exist on Ubuntu. Check if it's executable
and fall back to /bin/grep if it isn't.