### PR TITLE
texlive: fix SHA256

### DIFF
--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -2,8 +2,8 @@ class Texlive < Formula
   desc "TeX Live is a free software distribution for the TeX typesetting system"
   homepage "http://www.tug.org/texlive/"
   url "http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"
-  version "20160405"
-  sha256 "216829f4e5346694654b27d4607fcd7591831ff642d94753916e87ecb18a2885"
+  version "20160605"
+  sha256 "0cf6f2e520654411c19e634d42dd38ef8b4b7fdbfb78f4b82154641b640f0a4b"
   # tag "linuxbrew"
 
   option "with-full", "install everything"

--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -3,7 +3,7 @@ class Texlive < Formula
   homepage "http://www.tug.org/texlive/"
   url "http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"
   version "20160405"
-  sha256 "65e94212bf3fa63639ea929e6368ee248bf8904ea53d04566431e33ce4f173f6"
+  sha256 "216829f4e5346694654b27d4607fcd7591831ff642d94753916e87ecb18a2885"
   # tag "linuxbrew"
 
   option "with-full", "install everything"


### PR DESCRIPTION
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?

-----
before the fix:
```
$ brew install texlive
==> Downloading http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
==> Downloading from http://ctan.sharelatex.com/tex-archive/systems/texlive/tlnet/install-tl-unx.tar.gz
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: 65e94212bf3fa63639ea929e6368ee248bf8904ea53d04566431e33ce4f173f6
Actual: 216829f4e5346694654b27d4607fcd7591831ff642d94753916e87ecb18a2885
```
after the fix installation proceeds just fine
