### PR TITLE
ghostscript: depends on fontconfig for Linuxbrew

### DIFF
--- a/Formula/ghostscript.rb
+++ b/Formula/ghostscript.rb
@@ -43,6 +43,7 @@ class Ghostscript < Formula
   depends_on "djvulibre" if build.with? "djvu"
   depends_on :x11 => :optional
   depends_on "libidn" unless OS.mac?
+  depends_on "fontconfig" unless OS.mac?
 
   # https://sourceforge.net/projects/gs-fonts/
   resource "fonts" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

Fix error:

gs: error while loading shared libraries: libfontconfig.so.1: cannot open shared object file: No such file or directory