### PR TITLE
irssi: fix ncurses path

### DIFF
--- a/Formula/irssi.rb
+++ b/Formula/irssi.rb
@@ -37,7 +37,7 @@ class Irssi < Formula
       --enable-ipv6
       --enable-true-color
       --with-socks=#{build.with?("dante") ? "yes" : "no"}
-      --with-ncurses=#{MacOS.sdk_path}/usr
+      --with-ncurses=#{Formula["ncurses"].prefix}
     ]
 
     if build.with? "perl"

--- a/Formula/irssi.rb
+++ b/Formula/irssi.rb
@@ -37,7 +37,7 @@ class Irssi < Formula
       --enable-ipv6
       --enable-true-color
       --with-socks=#{build.with?("dante") ? "yes" : "no"}
-      --with-ncurses=#{Formula["ncurses"].prefix}
+      --with-ncurses=#{OS.mac? ? MacOS.sdk_path/"usr" : Formula["ncurses"].prefix}
     ]
 
     if build.with? "perl"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

`MacOS.sdk_path` returns nil, meaning that the formula expected ncurses to be installed in `/usr`, which tends not to be the case when ncurses is installed by Linuxbrew.