### PR TITLE
apr: Use cc instead of gcc-4.8

### DIFF
--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -3,7 +3,7 @@ class Apr < Formula
   homepage "https://apr.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=apr/apr-1.5.2.tar.bz2"
   sha256 "7d03ed29c22a7152be45b8e50431063736df9e1daa1ddf93f6a547ba7a28f67a"
-  revision 1
+  revision OS.mac? ? 1 : 2
 
   bottle do
     cellar :any
@@ -23,6 +23,11 @@ class Apr < Formula
     # https://bz.apache.org/bugzilla/show_bug.cgi?id=57359
     # The internal libtool throws an enormous strop if we don't do...
     ENV.deparallelize
+
+    if OS.linux? && build.bottle?
+      # Prevent hardcoded /usr/bin/gcc-4.8 compiler
+      ENV["CC"] = "cc"
+    end
 
     # Stick it in libexec otherwise it pollutes lib with a .exp file.
     system "./configure", "--prefix=#{libexec}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

The previous bottle hardcoded /usr/bin/gcc-4.8, which lead to Travis failing
to build apr-util since it doesn't have 4.8 available.