### PR TITLE
llvm: depends on gcc for Linuxbrew

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -142,6 +142,7 @@ class Llvm < Formula
   option "without-libffi", "Do not use libffi to call external functions"
   option "with-all-targets", "Build all targets. Default targets: AMDGPU, ARM, NVPTX, and X86"
 
+  depends_on "gcc" # latest gcc (5.x.x and above) is ABI incompatible with the old one
   depends_on "libffi" => :recommended # http://llvm.org/docs/GettingStarted.html#requirement
   depends_on "graphviz" => :optional # for the 'dot' tool (lldb)
   depends_on "ocaml" => :optional


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----
On Linux, `llvm` is built with `gcc`.
`gcc` 5.x and above is not ABI compatible with previous versions. Because of that, `llvm` that is built with old versions of `gcc` is not compatible with other software. We have to rebuild `llvm` using new `gcc` in order to make it compatible with other packages.
