### PR TITLE
apr: Recommend dependency on util-linux for Linuxbrew

### DIFF
--- a/Formula/apr.rb
+++ b/Formula/apr.rb
@@ -3,7 +3,7 @@ class Apr < Formula
   homepage "https://apr.apache.org/"
   url "https://www.apache.org/dyn/closer.cgi?path=apr/apr-1.5.2.tar.bz2"
   sha256 "7d03ed29c22a7152be45b8e50431063736df9e1daa1ddf93f6a547ba7a28f67a"
-  revision OS.mac? ? 2 : 3
+  revision OS.mac? ? 2 : 4
 
   bottle do
     cellar :any
@@ -16,6 +16,8 @@ class Apr < Formula
   keg_only :provided_by_osx, "Apple's CLT package contains apr."
 
   option :universal
+
+  depends_on "util-linux" => :recommended if OS.linux? # for libuuid
 
   def install
     ENV.universal_binary if build.universal?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

Dependant formulae of apr keep failing with "cannot find -luuid",
since it was somehow available when the apr bottle was created.
By making util-linux a recommended dependency, we ensure that
Circle will always have a UUID library available when building
bottles of apr-derived formulae.

See, for example, #869 and #819 