### PR TITLE
valgrind: Fix for Linuxbrew

### DIFF
--- a/Formula/valgrind.rb
+++ b/Formula/valgrind.rb
@@ -12,7 +12,7 @@ class Valgrind < Formula
     patch do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/86ecccf/valgrind/10.11_assertion.diff"
       sha256 "7e12fdb0f44cc0bfa8e721afce8218487405088c198d31b800f4741f32178e5c"
-    end
+    end if OS.mac?
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

Don't apply the 10.11 patch on Linux; it doesn't apply cleanly.