### PR TITLE
watchman: The bottle should only be cellar :any on Mac

### DIFF
--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -6,7 +6,8 @@ class Watchman < Formula
   head "https://github.com/facebook/watchman.git"
 
   bottle do
-    cellar :any
+    # Bottle hard-codes statedir. See https://github.com/Linuxbrew/homebrew-core/issues/956
+    cellar :any if OS.mac?
     sha256 "543ee937e060a61028041ce3f8ea490602fab29b1427bed40152d47e7baa523c" => :el_capitan
     sha256 "c9ab24b2585ec3cce5641e4a31610916dd5e1a101a0c0e7695516ff32b4e5e9d" => :yosemite
     sha256 "ee4ec6d737f55204f2b33a3701c494b66353550532a0ec600ee81668be8d6c54" => :mavericks


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

It hardcodes its statedir path, which leads to failure when that path
cannot be created on a different machine which lacks /home/linuxbrew.

Closes Linuxbrew/homebrew-core#956