### PR TITLE
llvm: Enable gold on Linux and add this support to LLVM

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -149,7 +149,7 @@ class Llvm < Formula
   unless OS.mac?
     depends_on "gcc" # <atomic> is provided by gcc
     depends_on "glibc" => GlibcRequirement.system_version.to_f >= 2.19 ? :optional : :recommended
-    depends_on "binutils" # for gold plugin
+    depends_on "binutils" if OS.linux? # needed for gold plugin
     depends_on "homebrew/dupes/libedit" # llvm requires <histedit.h>
     depends_on "libxml2"
     needs :cxx11
@@ -262,7 +262,7 @@ class Llvm < Formula
     end
 
     # Enable llvm gold plugin for LTO
-    args << "-DLLVM_BINUTILS_INCDIR=#{Formula["binutils"].opt_include}" unless OS.mac?
+    args << "-DLLVM_BINUTILS_INCDIR=#{Formula["binutils"].opt_include}" if OS.linux?
 
     if build.with? "libffi"
       args << "-DLLVM_ENABLE_FFI=ON"

--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -149,7 +149,7 @@ class Llvm < Formula
   unless OS.mac?
     depends_on "gcc" # <atomic> is provided by gcc
     depends_on "glibc" => GlibcRequirement.system_version.to_f >= 2.19 ? :optional : :recommended
-    depends_on "binutils" if build.with? "glibc"
+    depends_on "binutils" # for gold plugin
     depends_on "homebrew/dupes/libedit" # llvm requires <histedit.h>
     depends_on "libxml2"
     needs :cxx11
@@ -260,6 +260,9 @@ class Llvm < Formula
       args << "-DPYTHON_LIBRARY=#{pylib}"
       args << "-DPYTHON_INCLUDE_DIR=#{pyinclude}"
     end
+
+    # Enable llvm gold plugin for LTO
+    args << "-DLLVM_BINUTILS_INCDIR=#{Formula["binutils"].opt_include}" unless OS.mac?
 
     if build.with? "libffi"
       args << "-DLLVM_ENABLE_FFI=ON"


### PR DESCRIPTION
This patch enables gold linker in binutils and enables the LLVM gold linker plugins.

Gold is an ELF only linker, so it's only available under Linux.
