### PR TITLE
sphinx-doc: Use /usr/bin/env python for Linuxbrew

### DIFF
--- a/Formula/sphinx-doc.rb
+++ b/Formula/sphinx-doc.rb
@@ -85,6 +85,11 @@ class SphinxDoc < Formula
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
   end
 
+  def post_install
+    return if OS.mac? || (HOMEBREW_PREFIX/"bin/python").executable?
+    inreplace Dir[libexec/"bin/*"], HOMEBREW_PREFIX/"bin/python", "/usr/bin/env python", false
+  end
+
   test do
     system bin/"sphinx-quickstart", "-pPorject", "-aAuthor", "-v1.0", "-q"
     system bin/"sphinx-build", testpath, testpath/"build"


### PR DESCRIPTION
Use
 `#!/usr/bin/env python`
rather than
 `#!@@HOMEBREW_PREFIX@@/bin/python`

Fixes Linuxbrew/homebrew-core#1026.