### PR TITLE
neofetch: Only depend on screenresolution on macOS

### DIFF
--- a/Formula/neofetch.rb
+++ b/Formula/neofetch.rb
@@ -13,7 +13,7 @@ class Neofetch < Formula
     sha256 "15f36b6e099dba428645a9c125f9e5f70537949a66a10c280f48a693df0516c8" => :mavericks
   end
 
-  depends_on "screenresolution" => :recommended
+  depends_on "screenresolution" => :recommended if OS.mac?
   depends_on "imagemagick" => :recommended
 
   def install


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

screenresolution only works on Macs and isn't needed to determine the
screen resolution on Linux anyways.