### PR TITLE
v8: Fix for Linuxbrew

### DIFF
--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -68,6 +68,10 @@ class V8 < Formula
         :revision => "faee82e064e04e5cbf60cc7327e7a81d2a4557ad"
   end
 
+  fails_with :gcc do
+    cause "unrecognized command line option ‘-Wshorten-64-to-32’"
+  end
+
   def install
     # Bully GYP into correctly linking with c++11
     ENV.cxx11
@@ -105,8 +109,12 @@ class V8 < Formula
     include.install Dir["include/*"]
 
     cd "out/native" do
-      rm ["libgmock.a", "libgtest.a"]
-      lib.install Dir["lib*"]
+      if OS.mac?
+        rm ["libgmock.a", "libgtest.a"]
+        lib.install Dir["lib*"]
+      else
+        lib.install "lib.target/libv8.so"
+      end
       bin.install "d8", "mksnapshot", "process", "shell" => "v8"
     end
   end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

It still doesn't work with GCC, so we can't bottle this, but it fixes
the following issues when compiled with --cc=clang:

* Can't remove libgtest.a
* libv8.so not installed to lib