### PR TITLE
lua: Bump revision for Linuxbrew

### DIFF
--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -3,7 +3,7 @@ class Lua < Formula
   homepage "https://www.lua.org/"
   url "https://www.lua.org/ftp/lua-5.2.4.tar.gz"
   sha256 "b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b"
-  revision 4
+  revision OS.mac? ? 4 : 5
 
   bottle do
     cellar :any
@@ -18,7 +18,7 @@ class Lua < Formula
     reason "The bottle needs to be installed into /usr/local."
     # DomT4: I'm pretty sure this can be fixed, so don't leave this in place forever.
     # https://github.com/Homebrew/homebrew/issues/44619
-    satisfy { HOMEBREW_PREFIX.to_s == "/usr/local" }
+    satisfy { HOMEBREW_PREFIX.to_s == (OS.linux? ? "/home/linuxbrew/.linuxbrew" : "/usr/local") }
   end
 
   fails_with :llvm do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

New revision needed due to readline SONAME change.
Also, change the bottle-pouring logic.

Note that the revision bump conditions on OS.mac? rather than on
OS.linux? even though the bottle-pouring logic change only applies
to Linux. This is because readline was a marked as a dependency
everywhere except macOS.