### PR TITLE
v8: Fix building with GCC on Linuxbrew

### DIFF
--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -68,14 +68,11 @@ class V8 < Formula
         :revision => "faee82e064e04e5cbf60cc7327e7a81d2a4557ad"
   end
 
-  fails_with :gcc do
-    cause "unrecognized command line option ‘-Wshorten-64-to-32’"
-  end
-
   def install
     # Bully GYP into correctly linking with c++11
     ENV.cxx11
-    ENV["GYP_DEFINES"] = "clang=1 mac_deployment_target=#{MacOS.version}"
+    ENV["GYP_DEFINES"] = "clang=#{ENV.compiler == :clang || OS.mac? ? 1 : 0} mac_deployment_target=#{MacOS.version}"
+
     # https://code.google.com/p/v8/issues/detail?id=4511#c3
     ENV.append "GYP_DEFINES", "v8_use_external_startup_data=0"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

---

On Linux (but apparently not on macOS) an explicit clang=0 needs to be
provided to GYP_DEFINES in order to prevent using clang-only compiler
flags, even if GCC is the chosen compiler.
