### PR TITLE
fontconfig: Add option to skip doc building

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -30,6 +30,8 @@ class Fontconfig < Formula
     sha256 "ac91e177e6a9a8c077d403b1dd453de6d4c9d695b88a5d39ba0af0157c51a98c" => :x86_64_linux
   end
 
+  option "without-docs", "Skip building the fontconfig docs"
+
   pour_bottle? do
     default_prefix = BottleSpecification::DEFAULT_PREFIX
     reason "The bottle needs to be installed into #{default_prefix}."
@@ -58,13 +60,17 @@ class Fontconfig < Formula
   def install
     ENV.universal_binary if build.universal?
     system "autoreconf", "-iv" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--enable-static",
-                          "--with-add-fonts=/System/Library/Fonts,/Library/Fonts,~/Library/Fonts",
-                          "--prefix=#{prefix}",
-                          "--localstatedir=#{var}",
-                          "--sysconfdir=#{etc}"
+    args = [
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--enable-static",
+      "--with-add-fonts=/System/Library/Fonts,/Library/Fonts,~/Library/Fonts",
+      "--prefix=#{prefix}",
+      "--localstatedir=#{var}",
+      "--sysconfdir=#{etc}",
+    ]
+    args << "--disable-docs" if build.without? "docs"
+    system "./configure", *args
     system "make", "install", "RUN_FC_CACHE_TEST=false"
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

On some systems it is not possible to build fontconfig because we lack
docbook2pdf. This allows the building of fontconfig without any
docbook2pdf dependencies creeping in. As noted in issue Linuxbrew/legacy-linuxbrew#824