### PR TITLE
qt5: fix linux, add extra rpath for opt/qt5/lib, lower # of x11 deps …

### DIFF
--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -69,6 +69,8 @@ class Qt5 < Formula
   depends_on :postgresql => :optional
   depends_on :xcode => :build
 
+  depends_on :x11 unless OS.mac?
+
   depends_on OracleHomeVarRequirement if build.with? "oci"
 
   resource "qt-webkit" do

--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -89,8 +89,14 @@ class Qt5 < Formula
       -qt-freetype
       -qt-pcre
       -nomake tests
-      -no-rpath
     ]
+
+    if OS.mac?
+      args << "-no-rpath"
+    elsif OS.linux?
+      args << "-qt-xcb"
+      args << "-R#{lib}"
+    end
 
     args << "-nomake" << "examples" if build.without? "examples"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

The first thing this does is reduce the number of obscure x11 dependencies by passing -qt-xcb to the configure step, which allows qt to use its own implementation of some of the xcb stuff, allowing the build to go properly with just a standard :x11 dependency installed. 

The second thing this does is add -R #{lib} to the main configure line, which eventually results in an EXTRA_RPATH line being added to /.linuxbrew/opt/qt5/mkspecs/qmodule.pri when qmake is built

The added line looks like this: EXTRA_RPATHS +=  "/home/don/.linuxbrew/Cellar/qt5/5.6.1-1/lib"

This is important because when any other formula uses linuxbrew's qmake (important note, may want to tell people to add linuxbrew/opt/qt5/bin to their PATH for this) to configure its build, it will automatically use the proper qt5 libraries, without having to edit the build script to add LDFLAGS or to set LD_LIBRARY_PATH or LD_RUN_PATH.  This is especially important if you have a system that has an older version of qt that might confuse the dynamic linker, and you are wanting to use the updated version of QT under linuxbrew.

See also other rpath and ld_library_path type discussions

https://github.com/Linuxbrew/legacy-linuxbrew/issues/150
https://github.com/Homebrew/legacy-homebrew/issues/18990

For example in the experimental build of qscintilla2 linux Formula im doing, ldd shows the proper linkage, even without LD_LIBRARY_PATH being set, without the build script being hacked (it just uses qmake), and even though i have an older version of qt5 installed in the system using apt-get. 

```
don@ubuntu-32gb-nyc2-01:~/homebrew-core$ ldd ../.linuxbrew/lib/libqscintilla2.so       
 linux-vdso.so.1 =>  (0x00007ffdec5f9000)
	libQt5PrintSupport.so.5 => /home/don/.linuxbrew/Cellar/qt5/5.6.1-1/lib/libQt5PrintSupport.so.5 (0x00007f55720c1000)
	libQt5Widgets.so.5 => /home/don/.linuxbrew/Cellar/qt5/5.6.1-1/lib/libQt5Widgets.so.5 (0x00007f5571a71000)
	libQt5Gui.so.5 => /home/don/.linuxbrew/Cellar/qt5/5.6.1-1/lib/libQt5Gui.so.5 (0x00007f557155c000)
	libQt5Core.so.5 => /home/don/.linuxbrew/Cellar/qt5/5.6.1-1/lib/libQt5Core.so.5 (0x00007f557102e000)


```

Thanks


.
