### PR TITLE
ladspa-header: new formula

### DIFF
--- a/Formula/ladspa-header.rb
+++ b/Formula/ladspa-header.rb
@@ -1,0 +1,16 @@
+class LadspaHeader < Formula
+  desc "Linux Audio Developer's Simple Plugin API"
+  homepage "http://www.ladspa.org"
+  url "https://gist.githubusercontent.com/maxim-belkin/721fafe404e78e52cf3bf29a259ea9d2/raw/c50f363ec478e23e0bd5b28ea705b5ae52523abb/ladspa.h"
+  version "1.1"
+  sha256 "0c73624df742727076c65a9fec4c2806d37bcb7245f62e973d070048b6d333af"
+
+  def install
+    mkdir_p include.to_s
+    mv "ladspa.h", "#{include}/ladspa.h"
+  end
+
+  test do
+    assert File.exist?("#{include}/ladspa.h")
+  end
+end

--- a/Formula/ladspa-header.rb
+++ b/Formula/ladspa-header.rb
@@ -7,7 +7,7 @@ class LadspaHeader < Formula
 
   def install
     mkdir_p include.to_s
-    mv "ladspa.h", "#{include}/ladspa.h"
+    include.install "ladspa.h"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Does your submission pass `brew audit --new-formula <formula>` (after doing `brew install <formula>`)?

-----

This formula installs `ladspa.h`. Alternative solution to having this formula would be to use a resource in formulas that need `ladspa.h`.