### PR TITLE
terraform: Fix build for Linuxbrew: gofmt needs running

### DIFF
--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -74,7 +74,7 @@ class Terraform < Formula
       system "make", "bin"
 
       # Install release binary
-      bin.install "pkg/darwin_#{arch}/terraform"
+      bin.install "pkg/#{OS::NAME}_#{arch}/terraform"
       zsh_completion.install "contrib/zsh-completion/_terraform"
     end
   end


### PR DESCRIPTION
Fix Error: No such file or directory - pkg/darwin_amd64/terraform
