### PR TITLE
docbook-utils 0.6.14 (new formula) [WIP; do not merge]

### DIFF
--- a/Formula/docbook-utils.rb
+++ b/Formula/docbook-utils.rb
@@ -1,0 +1,22 @@
+class DocbookUtils < Formula
+  desc "Convert DocBook files to other formats (HTML, RTF, PS, man, PDF)"
+  homepage "https://www.sourceware.org/docbook-tools/"
+  url "ftp://sources.redhat.com/pub/docbook-tools/new-trials/SOURCES/docbook-utils-0.6.14.tar.gz"
+  sha256 "48faab8ee8a7605c9342fb7b906e0815e3cee84a489182af38e8f7c0df2e92e9"
+
+  depends_on "openjade"
+
+  def install
+    system "./configure",
+      "--disable-debug",
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/docbook2html", "--version"
+    assert_match "Usage", shell_output("#{bin}/docbook2html --version")
+  end
+end

--- a/Formula/openjade.rb
+++ b/Formula/openjade.rb
@@ -1,0 +1,22 @@
+class Openjade < Formula
+  desc "Implementation of the DSSSL language"
+  homepage "http://openjade.sourceforge.net"
+  url "http://downloads.sourceforge.net/openjade/openjade-1.3.2.tar.gz"
+  sha256 "1d2d7996cc94f9b87d0c51cf0e028070ac177c4123ecbfd7ac1cb8d0b7d322d1"
+
+  depends_on "opensp"
+
+  def install
+    system "./configure",
+      "--disable-debug",
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/jade", "--version"
+    assert_match "Usage", shell_output("#{bin}/jade --version")
+  end
+end

--- a/Formula/opensp.rb
+++ b/Formula/opensp.rb
@@ -1,0 +1,21 @@
+class Opensp < Formula
+  desc "OpenJade group's SGML parsing tools"
+  homepage "http://openjade.sourceforge.net/doc/"
+  url "http://downloads.sourceforge.net/openjade/OpenSP-1.5.2.tar.gz"
+  sha256 "57f4898498a368918b0d49c826aa434bb5b703d2c3b169beb348016ab25617ce"
+
+  depends_on "xmlto"
+
+  def install
+    system "./configure",
+      "--disable-debug",
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system "false" #xxx fixme
+  end
+end


### PR DESCRIPTION
+ docbook-utils 0.6.14 (new formula)
  Convert DocBook files to other formats (HTML, RTF, PS, man, PDF)
+ openjade 1.3.2 (new formula)
  Implementation of the DSSSL language
+ opensp 1.5.2 (new formula)
  OpenJade group's SGML parsing tools