### PR TITLE
xmlto: Depends on libxslt for Linuxbrew

### DIFF
--- a/Formula/xmlto.rb
+++ b/Formula/xmlto.rb
@@ -17,6 +17,7 @@ class Xmlto < Formula
   # Doesn't strictly depend on GNU getopt, but macOS system getopt(1)
   # does not support longopts in the optstring, so use GNU getopt.
   depends_on "gnu-getopt"
+  depends_on "libxslt" unless OS.mac?
 
   # xmlto forces --nonet on xsltproc, which causes it to fail when
   # DTDs/entities aren't available locally.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? *

-----

\* `xmlto` lacks a test, but that needs to be fixed upstream.

Came up during #1178. Dependency is necessary for `opensp` to build.

Note that I originally recommended making this a `:recommended` dependency, but I've instead made it a hard dep per https://packages.debian.org/jessie/xmlto.