### PR TITLE
w3m: Fix style for Linuxbrew

### DIFF
--- a/Formula/w3m.rb
+++ b/Formula/w3m.rb
@@ -28,7 +28,7 @@ class W3m < Formula
   def install
     # Fix istream.h:23:8: error: redefinition of 'struct file_handle'
     # See https://sourceforge.net/p/w3m/patches/62/
-    inreplace Dir["istream.[ch]"], "file_handle", "io_file_handle"
+    inreplace "istream.[ch]", "file_handle", "io_file_handle"
 
     system "./configure", "--prefix=#{prefix}", "--disable-image",
                           "--with-ssl=#{Formula["openssl"].opt_prefix}"


### PR DESCRIPTION
Dir["istream.[ch]"] is unnecessary; just use "istream.[ch]"