### PR TITLE
mapnik: Fix for Linuxbrew

### DIFF
--- a/Formula/mapnik.rb
+++ b/Formula/mapnik.rb
@@ -35,7 +35,9 @@ class Mapnik < Formula
   needs :cxx11
 
   def install
-    ENV.cxx11
+    # Fails with GCC 5. See https://github.com/Linuxbrew/homebrew-core/issues/1195
+    ENV.cxx11 if OS.mac?
+
     icu = Formula["icu4c"].opt_prefix
     boost = Formula["boost"].opt_prefix
     proj = Formula["proj"].opt_prefix


### PR DESCRIPTION
ENV.cxx11 fails with GCC 5.