### PR TITLE
cabal-install: upgrade to cabal-install 1.24.0.2, fixes #1365

### DIFF
--- a/Formula/cabal-install.rb
+++ b/Formula/cabal-install.rb
@@ -1,8 +1,8 @@
 class CabalInstall < Formula
   desc "Command-line interface for Cabal and Hackage"
   homepage "https://www.haskell.org/cabal/"
-  url "https://hackage.haskell.org/package/cabal-install-1.24.0.1/cabal-install-1.24.0.1.tar.gz"
-  sha256 "09f5fd8a2aa7f9565800a711a133f8142d36d59b38f59da09c25045b83ee9ecc"
+  url "https://hackage.haskell.org/package/cabal-install-1.24.0.2/cabal-install-1.24.0.2.tar.gz"
+  sha256 "2ac8819238a0e57fff9c3c857e97b8705b1b5fef2e46cd2829e85d96e2a00fe0"
   head "https://github.com/haskell/cabal.git", :branch => "1.24"
 
   bottle do
@@ -19,10 +19,6 @@ class CabalInstall < Formula
   def install
     cd "cabal-install" if build.head?
 
-    # Fix "'Distribution.Simple.Configure' does not export 'computeEffectiveProfiling'"
-    # Equivalent to upstream PR from 16 Nov 2016 https://github.com/haskell/cabal/pull/4117
-    inreplace "bootstrap.sh", 'CABAL_VER_REGEXP="1\.24\.[0-9]"',
-                              'CABAL_VER_REGEXP="1\.24\.[1-9]"'
     system "sh", "bootstrap.sh", "--sandbox"
     bin.install ".cabal-sandbox/bin/cabal"
     bash_completion.install "bash-completion/cabal"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?

See https://github.com/Linuxbrew/homebrew-core/issues/1365

- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

Modification and installation was run in [docker-linuxbrew](https://github.com/sjackman/docker-linuxbrew).

See logs:
```
$ brew doctor
Your system is ready to brew.
```
```
$ brew uninstall --force cabal-install
```

```
$ brew install --build-from-source cabal-install
==> Downloading https://hackage.haskell.org/package/cabal-install-1.24.0.2/cabal-install-1.24.0.2.tar.gz
######################################################################## 100.0%
==> sh bootstrap.sh --sandbox
==> Caveats
Bash completion has been installed to:
  /home/linuxbrew/.linuxbrew/etc/bash_completion.d

==> Summary
🍺  /home/linuxbrew/.linuxbrew/Cellar/cabal-install/1.24.0.2: 7 files, 20.5M, built in 16 minutes 34 seconds
```

```
$ brew test cabal-install
Testing cabal-install
==> /home/linuxbrew/.linuxbrew/Cellar/cabal-install/1.24.0.2/bin/cabal --config-file=/tmp/cabal-install-test-20161213-11159-18wkal1/config info cabal
```

- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

```
$ brew audit --strict cabal-install
==> Installing or updating 'rubocop' gem
Fetching: rainbow-2.1.0.gem (100%)
Successfully installed rainbow-2.1.0
Fetching: ast-2.3.0.gem (100%)
Successfully installed ast-2.3.0
Fetching: parser-2.3.3.1.gem (100%)
Successfully installed parser-2.3.3.1
Fetching: powerpack-0.1.1.gem (100%)
Successfully installed powerpack-0.1.1
Fetching: ruby-progressbar-1.8.1.gem (100%)
Successfully installed ruby-progressbar-1.8.1
Fetching: unicode-display_width-1.1.2.gem (100%)
Successfully installed unicode-display_width-1.1.2
Fetching: rubocop-0.45.0.gem (100%)
Successfully installed rubocop-0.45.0
7 gems installed
```
```
$ brew audit --strict cabal-install
```
-----

I am not sure if I should make this PR upstream - i.e. to Homebrew  (also because I do not know hot to test it), so I am submitting it here.
