### PR TITLE
ghc 8.0.1: build ghc 8.0.1 from source using a binary release of ghc 8.0.1

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -78,8 +78,8 @@ class Ghc < Formula
     if OS.linux?
       # Using 8.0.1 gives the error message:
       # strip: Not enough room for program headers, try linking with -N
-      url "http://downloads.haskell.org/~ghc/7.8.4/ghc-7.8.4-x86_64-unknown-linux-deb7.tar.xz"
-      sha256 "f62e00e93a5ac16ebfe97cd7cb8cde6c6f3156073d4918620542be3e0ad55f8d"
+      url "http://downloads.haskell.org/~ghc/8.0.1/ghc-8.0.1-x86_64-deb7-linux.tar.xz"
+      sha256 "86a8109dfa4ec000e0048ed9d072c0d232affeb1069ca96b3995cb5cef2230a7"
     elsif MacOS.version >= :sierra
       url "https://downloads.haskell.org/~ghc/8.0.2-rc1/ghc-8.0.1.20161117-x86_64-apple-darwin.tar.xz"
       sha256 "6086ac08be3733c8817328c99c4af66f5a2feba02d4be4b0dc0aeac5acf0360e"

--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -54,6 +54,11 @@ class Ghc < Formula
   # This dependency is needed for the bootstrap executables.
   depends_on "gmp" => :build if OS.linux?
 
+  # binutils on Travis-CI is old and buggy
+  if ENV["TRAVIS"]
+    depends_on "binutils" => :build if OS.linux?
+  end
+
   resource "gmp" do
     url "https://ftpmirror.gnu.org/gmp/gmp-6.1.1.tar.xz"
     mirror "https://gmplib.org/download/gmp/gmp-6.1.1.tar.xz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
-----

***WARNING: this pull request is not complete yet***

(splitting from #1366 for clarity)

Premise: `ghc`, the Glasgow Haskell Compiler, is written in Haskell so it needs a binary of itself to build from source.

the current stable release of `ghc` is `8.0.1` and in Linuxbrew building from source is currently using a binary release of `ghc v. 7.8.4` ([ghc.rb#L81](https://github.com/Linuxbrew/homebrew-core/blob/master/Formula/ghc.rb#L81)).

Build with a binary release of `ghc 8.0.1` is known to cause the following problem ([ghc.rb#L79-L80](https://github.com/Linuxbrew/homebrew-core/blob/master/Formula/ghc.rb#L79-L80)):
```
# Using 8.0.1 gives the error message:
# strip: Not enough room for program headers, try linking with -N
```
However, I am not able to reproduce the error on [docker-linuxbrew](https://github.com/sjackman/docker-linuxbrew) and besides an error in linking libraries which I am able to resolve with `brew patchelf ghc` (see [#851](https://github.com/Linuxbrew/homebrew-core/issues/851#issuecomment-266402224)), I am able to build it from source. See the full [logs](http://pastebin.com/raw/AK2yGciV).

I am opening this PR, but I consider it incomplete because on one hand I can not reproduce the existing issue and on the other it is not working completely. Help wanted.

