### PR TITLE
llvm: depends on python for lldb & python

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -139,6 +139,7 @@ class Llvm < Formula
 
   depends_on "libffi" => :recommended # http://llvm.org/docs/GettingStarted.html#requirement
   depends_on "graphviz" => :optional # for the 'dot' tool (lldb)
+  depends_on "python" if build.with?("python") || build.with?("lldb")
 
   depends_on "ocaml" => :optional
   if build.with? "ocaml"


### PR DESCRIPTION
This pull request makes llvm depend on python and swig when --with-lldb, fixes #1398 

It also fixes the build failure under both --with-python and --with-lldb.