### PR TITLE
binutils: enable gold and other fixes

### DIFF
--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -4,6 +4,7 @@ class Binutils < Formula
   url "https://ftpmirror.gnu.org/binutils/binutils-2.27.tar.gz"
   mirror "https://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz"
   sha256 "26253bf0f360ceeba1d9ab6965c57c6a48a01a8343382130d1ed47c468a3094f"
+  revision 1 if OS.linux?
 
   bottle do
     cellar :any if OS.linux?
@@ -31,9 +32,12 @@ class Binutils < Formula
                           "--enable-interwork",
                           "--enable-multilib",
                           "--enable-64-bit-bfd",
+                          ("--enable-gold" if OS.linux?),
+                          ("--enable-plugins" if OS.linux?),
                           "--enable-targets=all"
     system "make"
     system "make", "install"
+    bin.install_symlink "ld.gold" => "gold" if OS.linux?
   end
 
   test do


### PR DESCRIPTION
1. Build gold linker
2. Add a build-time recommended dependency on 'texinfo':
    - 'makeinfo' (provided by 'texinfo') is missing on Linux
    - needed to generate documentation
3. Add a build-time dependency on 'bison':
    - 'bison' is missing on Linux
    - needed to build gold linker

Required for #1006

----

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?