### PR TITLE
infer: Fix SHA256 for Linuxbrew

### DIFF
--- a/Formula/infer.rb
+++ b/Formula/infer.rb
@@ -6,7 +6,7 @@ class Infer < Formula
     sha256 "a738a3492a4e0229df8abd745cd88bca8fb547bc3bcca15ec194d6780b07cbda"
   elsif OS.linux?
     url "https://github.com/facebook/infer/releases/download/v0.9.4.1/infer-linux64-v0.9.4.1.tar.xz"
-    sha256 "5"
+    sha256 "dcab2161603ef17a119715c24d6a41c689089352c5a23f1996f5695de7b8d584"
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Apparently I forgot to fix this when I merged homebrew into linuxbrew.