### PR TITLE
browser: use xdg-open except on Macs

### DIFF
--- a/Formula/browser.rb
+++ b/Formula/browser.rb
@@ -10,6 +10,7 @@ class Browser < Formula
   bottle :unneeded
 
   def install
+    inreplace "browser", 'exec "open', 'exec "xdg-open' unless OS.mac?
     bin.install "browser"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

The `open` command might be available on Linux, but it doesn't do the same thing it does on Mac. `xdg-open` is closer.