### PR TITLE
Add missing build-dependency `libuuid` for mosquitto

### DIFF
--- a/Formula/mosquitto.rb
+++ b/Formula/mosquitto.rb
@@ -13,6 +13,7 @@ class Mosquitto < Formula
 
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
+  depends_on "libuuid" => :build
   depends_on "c-ares"
   depends_on "openssl"
   depends_on "libwebsockets" => :recommended

--- a/Formula/mosquitto.rb
+++ b/Formula/mosquitto.rb
@@ -13,7 +13,7 @@ class Mosquitto < Formula
 
   depends_on "pkg-config" => :build
   depends_on "cmake" => :build
-  depends_on "libuuid" => :build
+  depends_on "util-linux" if OS.linux? # for libuuid
   depends_on "c-ares"
   depends_on "openssl"
   depends_on "libwebsockets" => :recommended


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----


I had an error while installing the formula:
```
==> cmake . -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG
==> make install
Last 15 lines from /home/sho/.cache/Homebrew/Logs/mosquitto/02.make:
make[2]: Leaving directory `/tmp/mosquitto-20161230-20633-mi7xje/mosquitto-1.4.10'
[ 98%] Built target mosquitto_sub
/home/sho/.linuxbrew/bin/ld: cannot find -luuid
collect2: error: ld returned 1 exit status
make[2]: *** [src/mosquitto] Error 1
```

After executing `brew install libuuid` it works for me. `libuuid` should be there marked as a dependency, shouldn't it? :)