### PR TITLE
intltool: Depends on XML::Parser Perl Module for Linuxbrew

### DIFF
--- a/Formula/intltool.rb
+++ b/Formula/intltool.rb
@@ -14,6 +14,8 @@ class Intltool < Formula
     sha256 "2b0bc62fa22240902e2bc04b91d6f25b0989e224953ed99ad66d06ad9b37b34d" => :x86_64_linux
   end
 
+  depends_on "XML::Parser" => :perl unless OS.mac?
+
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--disable-silent-rules"


### PR DESCRIPTION
Fix error:
    XML::Parser perl module is required for intltool

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See https://github.com/Linuxbrew/homebrew-xorg/pull/249#issuecomment-269868800