### PR TITLE
diffoscope: Fix for Linuxbrew

### DIFF
--- a/Formula/diffoscope.rb
+++ b/Formula/diffoscope.rb
@@ -49,7 +49,7 @@ class Diffoscope < Formula
     ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python#{pyver}/site-packages"
     system "python3", *Language::Python.setup_install_args(libexec)
     bin.install Dir[libexec/"bin/*"]
-    libarchive = Formula["libarchive"].opt_lib/"libarchive.dylib"
+    libarchive = Formula["libarchive"].opt_lib/"libarchive.#{OS.mac? ? "dylib" : "so"}"
     bin.env_script_all_files(libexec+"bin", :PYTHONPATH => ENV["PYTHONPATH"],
                                             :LIBARCHIVE => libarchive)
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

`diffoscope` compiles fine, but it fails at runtime with:

```
OSError: /home/linuxbrew/.linuxbrew/opt/libarchive/lib/libarchive.dylib: cannot open shared object file: No such file or directory
```