### PR TITLE
tldr: Depends on curl for Linuxbrew

### DIFF
--- a/Formula/tldr.rb
+++ b/Formula/tldr.rb
@@ -15,6 +15,7 @@ class Tldr < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libzip"
+  depends_on "curl" unless OS.mac?
 
   def install
     system "make", "PREFIX=#{prefix}", "install"


### PR DESCRIPTION
All credit goes to zmwangx, who provided the solution at #1471.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I couldn't do a strict audit of the formula due to a gem error ([log](https://gist.github.com/waldyrious/4a461d42ac410b79e046084a8974d757)), but since the change is pretty minimal, I assume there should be no issues.

I also tried to test the formula, but I'm not sure the failure is related:
```
$ brew test tldr
Testing tldr
==> /home/waldyrious/.linuxbrew/Cellar/tldr/1.3.0/bin/tldr brew
Error: tldr: failed
<0> expected but was
<1>.
```
The build did conclude successfully and I'm able to use the tldr command as expected.