### PR TITLE
libmetalink: Depends on expat for Linuxbrew

### DIFF
--- a/Formula/libmetalink.rb
+++ b/Formula/libmetalink.rb
@@ -14,7 +14,7 @@ class Libmetalink < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "libxml2" unless OS.mac?
+  depends_on "expat" unless OS.mac?
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
It does not depend on libxml2.