### PR TITLE
util-linux: Disable systemd

### DIFF
--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -23,6 +23,8 @@ class UtilLinux < Formula
       "--disable-kill",
       # Conflicts with bsdmainutils
       "--disable-cal",
+      # Disable systemd. Linuxbrew is non-root
+      "--without-systemd",
       "--disable-ul"
     system "make", "install"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Disable systemd in `util-linux`, otherwise could cause build error. `util-linux` installs host system wide systemd services. Linuxbrew packages are suppose to install in an non-root environment. So, this pull request completely disabled systemd.

Fixes #1523.