### PR TITLE
guile: Depends on gperf for Linuxbrew

### DIFF
--- a/Formula/guile.rb
+++ b/Formula/guile.rb
@@ -44,6 +44,7 @@ class Guile < Formula
   depends_on "bdw-gc"
   depends_on "gmp"
   depends_on "readline"
+  depends_on "homebrew/dupes/gperf" unless OS.mac?
 
   fails_with :clang do
     build 211


### PR DESCRIPTION
Fix error: gperf: command not found

Supersedes #108