### PR TITLE
guile: fix test + add caveats for Linuxbrew bottle

### DIFF
--- a/Formula/guile.rb
+++ b/Formula/guile.rb
@@ -77,7 +77,15 @@ class Guile < Formula
     (share/"gdb/auto-load").install Dir["#{lib}/*-gdb.scm"]
   end
 
+  def caveats
+    <<-EOS.undent
+    When using a bottle, set the environment variable GUILE_LOAD_PATH to:
+    #{share}/guile/2.0
+    EOS
+  end unless OS.mac?
+
   test do
+    ENV["GUILE_LOAD_PATH"] = "#{share}/guile/2.0" unless OS.mac?
     hello = testpath/"hello.scm"
     hello.write <<-EOS.undent
     (display "Hello World")


### PR DESCRIPTION
When force-installing a bottle for Linuxbrew, one can make the bottle to work even in a non-standard location  by setting an environment variable GUILE_LOAD_PATH. This fix does exactly that.