### PR TITLE
wxmac: Build a bottle for Linuxbrew: Depends on xorg/xorg/mesa

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -1,3 +1,4 @@
+# wxmac: Build a bottle for Linuxbrew
 class Wxmac < Formula
   desc "wxWidgets, a cross-platform C++ GUI toolkit (for macOS)"
   homepage "https://www.wxwidgets.org"

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
   override:
     - sudo apt-get update
     - sudo apt-get install curl g++ git libperl-dev libxml-parser-perl libxml-sax-perl make python-dev ruby2.0 ruby2.0-dev subversion wbritish
-    - DEBIAN_FRONTEND=noninteractive sudo apt-get autoremove -y --purge libblas-dev libicu-dev libjasper-dev libjbig-dev libncurses5-dev libpcre3-dev libtinfo-dev libwebp-dev libxml2-dev llvm-3.4 mysql-common
+    - DEBIAN_FRONTEND=noninteractive sudo apt-get autoremove -y --purge libblas-dev libgl1-mesa-dev libicu-dev libjasper-dev libjbig-dev libncurses5-dev libpcre3-dev libtinfo-dev libwebp-dev libxml2-dev llvm-3.4 mysql-common
     - sudo ln -sf ruby2.0 /usr/bin/ruby
     - sudo ln -sf gem2.0 /usr/bin/gem
     - sudo ln -sf /usr/lib/x86_64-linux-gnu/libruby-2.0.so /usr/lib/x86_64-linux-gnu/libruby.so


### PR DESCRIPTION
Remove `libgl1-mesa-dev` to hopefully fix:
```
==> brew linkage --test wxmac
Missing libraries:
  libGL.so.1
==> FAILED
```
https://travis-ci.org/Linuxbrew/homebrew-core/builds/190784706#L2464