### PR TITLE
mongodb: Depends on libpcap for Linuxbrew

### DIFF
--- a/Formula/mongodb.rb
+++ b/Formula/mongodb.rb
@@ -23,7 +23,7 @@ class Mongodb < Formula
 
   if OS.linux?
     depends_on "gcc" # Fails with GCC < 5.3
-    depends_on "homebrew/dupes/libpcap" => :build
+    depends_on "libpcap" => :build
     depends_on "pkg-config" => :build
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

fix https://github.com/Linuxbrew/homebrew-core/pull/235

by adding `depends_on "homebrew/dupes/libpcap"`

path/brew/Cellar/mongodb/3.4.1: 16 files, 2.0G, built in 7 minutes 26 seconds

@sjackman 

EDIT: looks like the issue this fixes has been turned into a PR (also pending on travis failing):  https://github.com/Linuxbrew/homebrew-core/pull/235