### PR TITLE
openssl:add makedepend dependency on linux

### DIFF
--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -32,9 +32,8 @@ class Openssl < Formula
 
   deprecated_option "without-check" => "without-test"
 
-  if OS.mac?
-    depends_on "makedepend" => :build
-  else
+  depends_on "makedepend" => :build
+  unless OS.mac?
     depends_on "zlib"
     depends_on :perl => ["5.0", :build]
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
`makedepend` remain to be necessary with existed patch.
[here](https://gist.github.com/anonymous/d9484f310b164fab01324788a01c9eb8) is my gist-logs