### PR TITLE
gcc: Add option without-sanitizer: error: 'PTRACE_GETSIGINFO' was not declared

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -48,6 +48,7 @@ class Gcc < Formula
   else
     option "with-multilib", "Build with multilib support"
   end
+  option "without-sanitizer", "Build without libsanitizer" if OS.linux?
 
   depends_on "zlib" unless OS.mac?
   depends_on "binutils" if build.with? "glibc"
@@ -176,6 +177,7 @@ class Gcc < Formula
 
     args << "--enable-host-shared" if build.with?("jit") || build.with?("all-languages")
 
+    args << "--disable-libsanitizer" if build.without? "sanitizer"
     # Ensure correct install names when linking against libgcc_s;
     # see discussion in https://github.com/Homebrew/homebrew/pull/34303
     inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"

--- a/Formula/gcc@4.9.rb
+++ b/Formula/gcc@4.9.rb
@@ -56,6 +56,7 @@ class GccAT49 < Formula
   option "with-profiled-build", "Make use of profile guided optimization when bootstrapping GCC"
   # enabling multilib on a host that can't run 64-bit results in build failures
   option "without-multilib", "Build without multilib support" if MacOS.prefer_64_bit?
+  option "without-sanitizer", "Build without libsanitizer" if OS.linux?
 
   deprecated_option "enable-java" => "with-java"
   deprecated_option "enable-all-languages" => "with-all-languages"
@@ -147,6 +148,7 @@ class GccAT49 < Formula
     else
       args << "--enable-multilib"
     end
+    args << "--disable-libsanitizer" if build.without? "sanitizer"
 
     # Ensure correct install names when linking against libgcc_s;
     # see discussion in https://github.com/Homebrew/homebrew/pull/34303


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
[here](https://gist.github.com/anonymous/3f8032d28efe88ec4cf65d0e0aa247df#file-02-make-L2314) is gist-logs.
in some old system without ptrace or with old ptrace, gcc's sanitizerr will failed
and I add a option to disable it
reference: [https://gcc.gnu.org/ml/gcc-help/2014-08/msg00005.html](https://gcc.gnu.org/ml/gcc-help/2014-08/msg00005.html)