### PR TITLE
Circle: rerun the configuration dialog for CPAN.pm

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,7 @@ dependencies:
   override:
     - sudo apt-get update
     - sudo apt-get install curl g++ git libperl-dev libxml-parser-perl libxml-sax-perl make python-dev ruby2.0 ruby2.0-dev subversion wbritish
+    - (echo y;echo o conf prerequisites_policy follow;echo o conf commit)|cpan
     - DEBIAN_FRONTEND=noninteractive sudo apt-get autoremove -y --purge libblas-dev libicu-dev libjasper-dev libjbig-dev libncurses5-dev libpcre3-dev libtinfo-dev libwebp-dev libwmf-dev libxml2-dev llvm-3.4 mysql-common
     - sudo ln -sf ruby2.0 /usr/bin/ruby
     - sudo ln -sf gem2.0 /usr/bin/gem

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
   override:
     - sudo apt-get update
     - sudo apt-get install curl g++ git libperl-dev libxml-parser-perl libxml-sax-perl make python-dev ruby2.0 ruby2.0-dev subversion wbritish
-    - printf "yes\nsudo\nyes\no conf prerequisites_policy follow\no conf commit\n" | cpan
+    - printf "yes\nsudo\nyes\no conf prerequisites_policy follow\no conf commit\n" | cpan # https://github.com/Linuxbrew/homebrew-core/pull/1614
     - DEBIAN_FRONTEND=noninteractive sudo apt-get autoremove -y --purge libblas-dev libicu-dev libjasper-dev libjbig-dev libncurses5-dev libpcre3-dev libtinfo-dev libwebp-dev libwmf-dev libxml2-dev llvm-3.4 mysql-common
     - sudo ln -sf ruby2.0 /usr/bin/ruby
     - sudo ln -sf gem2.0 /usr/bin/gem

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
   override:
     - sudo apt-get update
     - sudo apt-get install curl g++ git libperl-dev libxml-parser-perl libxml-sax-perl make python-dev ruby2.0 ruby2.0-dev subversion wbritish
-    - printf "yes\nsudo\nyes\no conf prerequisites_policy follow\no conf commit\n" | cpan # https://github.com/Linuxbrew/homebrew-core/pull/1614
+    - printf "yes\nsudo\nyes\no conf prerequisites_policy follow\no conf commit\n" | cpan # https://github.com/Linuxbrew/homebrew-core/pull/1614#issuecomment-274313223
     - DEBIAN_FRONTEND=noninteractive sudo apt-get autoremove -y --purge libblas-dev libicu-dev libjasper-dev libjbig-dev libncurses5-dev libpcre3-dev libtinfo-dev libwebp-dev libwmf-dev libxml2-dev llvm-3.4 mysql-common
     - sudo ln -sf ruby2.0 /usr/bin/ruby
     - sudo ln -sf gem2.0 /usr/bin/gem

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
   override:
     - sudo apt-get update
     - sudo apt-get install curl g++ git libperl-dev libxml-parser-perl libxml-sax-perl make python-dev ruby2.0 ruby2.0-dev subversion wbritish
-    - (echo y;echo o conf prerequisites_policy follow;echo o conf commit)|cpan
+    - printf "yes\nsudo\nyes\no conf prerequisites_policy follow\no conf commit\n" | cpan
     - DEBIAN_FRONTEND=noninteractive sudo apt-get autoremove -y --purge libblas-dev libicu-dev libjasper-dev libjbig-dev libncurses5-dev libpcre3-dev libtinfo-dev libwebp-dev libwmf-dev libxml2-dev llvm-3.4 mysql-common
     - sudo ln -sf ruby2.0 /usr/bin/ruby
     - sudo ln -sf gem2.0 /usr/bin/gem


### PR DESCRIPTION
If we run `cpan` after installing `XML::Parser` via
`sudo apt-get install ...` we get the following error message:

```
Sorry, we have to rerun the configuration dialog for CPAN.pm due to
some missing parameters.
...
```

This PR reruns this configuration in an automated way.
Code snippet by Clayton Dukes found [here](http://stackoverflow.com/questions/3462058/how-do-i-automate-cpan-configuration)