### PR TITLE
govendor: Fix for Linuxbrew

### DIFF
--- a/Formula/govendor.rb
+++ b/Formula/govendor.rb
@@ -17,7 +17,7 @@ class Govendor < Formula
   def install
     ENV["GOPATH"] = buildpath
     ENV["GOOS"] = "darwin" if OS.mac?
-    ENV["GOARCH"] = MacOS.prefer_64_bit? ? "amd64" : "386" if OS.mac?
+    ENV["GOARCH"] = MacOS.prefer_64_bit? ? "amd64" : "386"
 
     (buildpath/"src/github.com/kardianos/").mkpath
     ln_sf buildpath, buildpath/"src/github.com/kardianos/govendor"

--- a/Formula/govendor.rb
+++ b/Formula/govendor.rb
@@ -16,8 +16,8 @@ class Govendor < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    ENV["GOOS"] = "darwin"
-    ENV["GOARCH"] = MacOS.prefer_64_bit? ? "amd64" : "386"
+    ENV["GOOS"] = "darwin" if OS.mac?
+    ENV["GOARCH"] = MacOS.prefer_64_bit? ? "amd64" : "386" if OS.mac?
 
     (buildpath/"src/github.com/kardianos/").mkpath
     ln_sf buildpath, buildpath/"src/github.com/kardianos/govendor"


### PR DESCRIPTION
This commit fixes not to build for darwin. In this case, GOOS and GOARCH
shoud not be needed to set.


Signed-off-by: Kazuki Suda <kazuki.suda@gmail.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
