### PR TITLE
gmp: add ABI=32 on 32bit linux

### DIFF
--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -20,6 +20,7 @@ class Gmp < Formula
     ENV.cxx11 if build.cxx11?
     args = %W[--prefix=#{prefix} --enable-cxx]
     args << "--build=core2-apple-darwin#{`uname -r`.to_i}" if build.bottle? && OS.mac?
+    args << "ABI=32" if Hardware::CPU.is_32_bit? && !OS.mac?
     system "./configure", *args
     system "make"
     system "make", "check"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
[gist-logs](https://gist.github.com/5b6ea502abc5a390fa23eb9978366947)
see #1590 