### PR TITLE
glibc: fix expand  on 64 bit linux

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -33,6 +33,10 @@ class Glibc < Formula
         # Fix error: selinux/selinux.h: No such file or directory
         "--without-selinux",
       ]
+      if Hardware::CPU.is_64_bit?
+        args << "--libdir=#{prefix}/lib64"
+        args << "libc_cv_slibdir=#{prefix}/lib64"
+      end
       kernel_version = `uname -r`.chomp.split("-")[0]
       args << "--enable-kernel=#{kernel_version}" if build.with? "current-kernel"
       args << "--with-binutils=#{Formula["binutils"].bin}" if build.with? "binutils"
@@ -41,7 +45,11 @@ class Glibc < Formula
 
       system "make" # Fix No rule to make target libdl.so.2 needed by sprof
       system "make", "install"
-      prefix.install_symlink "lib" => "lib64"
+
+      if Hardware::CPU.is_64_bit?
+        mv prefix/"lib64", prefix/"lib"
+        prefix.install_symlink "lib" => "lib64"
+      end 
     end
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
**Background**: `ld.so` provided by `glibc` can not expand `$LIB` to `lib64` on 64-bit Linux. 
This makes some exists configs fail. See [ld.so manual page](http://man7.org/linux/man-pages/man8/ld.so.8.html)

**Example**: `LD_PRELOAD=/$LIB/libfoo.so`
According to `glibc`'s source code, `$LIB` is expanded to `DL_DST_LIB` which depends on `libc_cv_slibdir`. The latter one is set to `lib64` only when `prefix=/usr` (from `configure` file like `sysdeps/gnu/configure.ac`). Hence, we must set `libc_cv_slibdir` and `libdir` to `lib64` explicitly.
And move `lib64` to `lib` for compatibility