### PR TITLE
circle.yml: fix `permission denied` problem caused by #1614

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,7 @@ dependencies:
     - sudo apt-get update
     - sudo apt-get install curl g++ git libperl-dev libxml-parser-perl libxml-sax-perl make python-dev ruby2.0 ruby2.0-dev subversion wbritish
     - printf "yes\nlocal::lib\nyes\nyes\no conf prerequisites_policy follow\no conf commit\n" | cpan # https://github.com/Linuxbrew/homebrew-core/pull/1614#issuecomment-274313223
-    - source /home/linuxbrew/.bashrc
+    - source "$HOME"/.bashrc
     - DEBIAN_FRONTEND=noninteractive sudo apt-get autoremove -y --purge libblas-dev libicu-dev libjasper-dev libjbig-dev libncurses5-dev libpcre3-dev libtinfo-dev libwebp-dev libwmf-dev libxml2-dev llvm-3.4 mysql-common
     - sudo ln -sf ruby2.0 /usr/bin/ruby
     - sudo ln -sf gem2.0 /usr/bin/gem

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ dependencies:
   override:
     - sudo apt-get update
     - sudo apt-get install curl g++ git libperl-dev libxml-parser-perl libxml-sax-perl make python-dev ruby2.0 ruby2.0-dev subversion wbritish
-    - printf "yes\nlocal::lib\nyes\nyes\no conf prerequisites_policy follow\no conf commit\n" | cpan # https://github.com/Linuxbrew/homebrew-core/pull/1614#issuecomment-274313223
+    - printf "yes\nlocal::lib\nyes\nyes\no conf prerequisites_policy follow\no conf build_requires_install_policy yes\no conf commit\n" | cpan # https://github.com/Linuxbrew/homebrew-core/pull/1621#issue-202644521
     - source "$HOME"/.bashrc
     - DEBIAN_FRONTEND=noninteractive sudo apt-get autoremove -y --purge libblas-dev libicu-dev libjasper-dev libjbig-dev libncurses5-dev libpcre3-dev libtinfo-dev libwebp-dev libwmf-dev libxml2-dev llvm-3.4 mysql-common
     - sudo ln -sf ruby2.0 /usr/bin/ruby

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,6 @@ dependencies:
     - sudo apt-get update
     - sudo apt-get install curl g++ git libperl-dev libxml-parser-perl libxml-sax-perl make python-dev ruby2.0 ruby2.0-dev subversion wbritish
     - printf "yes\nlocal::lib\nyes\nyes\no conf prerequisites_policy follow\no conf build_requires_install_policy yes\no conf commit\n" | cpan # https://github.com/Linuxbrew/homebrew-core/pull/1621#issue-202644521
-    - source "$HOME"/.bashrc
     - DEBIAN_FRONTEND=noninteractive sudo apt-get autoremove -y --purge libblas-dev libicu-dev libjasper-dev libjbig-dev libncurses5-dev libpcre3-dev libtinfo-dev libwebp-dev libwmf-dev libxml2-dev llvm-3.4 mysql-common
     - sudo ln -sf ruby2.0 /usr/bin/ruby
     - sudo ln -sf gem2.0 /usr/bin/gem
@@ -31,9 +30,9 @@ test:
   override:
     - umask 022;
       PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH";
+      eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)";
       brew install patchelf
         && brew tap homebrew/dupes
         && brew tap linuxbrew/xorg
         && brew test-bot --tap=homebrew/core --keep-old
-    - [[ $(find . -maxdepth 1 -type f -iname "*.json" | wc -l) > 0 ]] &&  mv *.json $CIRCLE_ARTIFACTS/
-    - [[ $(find . -maxdepth 1 -type f -iname "*.tar.gz" | wc -l) > 0 ]] &&  mv *.tar.gz $CIRCLE_ARTIFACTS/
+    - mv *.json *.tar.gz $CIRCLE_ARTIFACTS/ || true

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,8 @@ dependencies:
   override:
     - sudo apt-get update
     - sudo apt-get install curl g++ git libperl-dev libxml-parser-perl libxml-sax-perl make python-dev ruby2.0 ruby2.0-dev subversion wbritish
-    - printf "yes\nsudo\nyes\no conf prerequisites_policy follow\no conf commit\n" | cpan # https://github.com/Linuxbrew/homebrew-core/pull/1614#issuecomment-274313223
+    - printf "yes\nlocal::lib\nyes\nyes\no conf prerequisites_policy follow\no conf commit\n" | cpan # https://github.com/Linuxbrew/homebrew-core/pull/1614#issuecomment-274313223
+    - source /home/linuxbrew/.bashrc
     - DEBIAN_FRONTEND=noninteractive sudo apt-get autoremove -y --purge libblas-dev libicu-dev libjasper-dev libjbig-dev libncurses5-dev libpcre3-dev libtinfo-dev libwebp-dev libwmf-dev libxml2-dev llvm-3.4 mysql-common
     - sudo ln -sf ruby2.0 /usr/bin/ruby
     - sudo ln -sf gem2.0 /usr/bin/gem

--- a/circle.yml
+++ b/circle.yml
@@ -35,4 +35,5 @@ test:
         && brew tap homebrew/dupes
         && brew tap linuxbrew/xorg
         && brew test-bot --tap=homebrew/core --keep-old
-    - mv *.json *.tar.gz $CIRCLE_ARTIFACTS/
+    - [[ $(find . -maxdepth 1 -type f -iname "*.json" | wc -l) > 0 ]] &&  mv *.json $CIRCLE_ARTIFACTS/
+    - [[ $(find . -maxdepth 1 -type f -iname "*.tar.gz" | wc -l) > 0 ]] &&  mv *.tar.gz $CIRCLE_ARTIFACTS/


### PR DESCRIPTION
After we merged #1614, uninstalling perl on Circle causes a `permission denied` error because some of the files are owned by root and Linuxbrew refuses to escalate privileges. In this PR we take another approach to reconfigure cpan. This time we use `local::lib` instead of `sudo`. Because of that, we have to answer one extra question.


Questions that `cpan` asks during reconfiguration:
```
1. Would you like to configure as much as possible automatically? [yes]
2. What approach do you want?  (Choose 'local::lib', 'sudo' or 'manual')
 [local::lib]
3. Would you like me to automatically choose some CPAN mirror
sites for you? (This means connecting to the Internet) [yes]
4. Would you like me to append that to /home/linuxbrew/.bashrc now? [yes]
```
Our answers:
```
1. yes
2. local::lib
3. yes
4. yes
```
After that, we execute the following code in `cpan`'s shell:
```
o conf prerequisites_policy follow
o conf build_requires_install_policy yes
o conf commit
```
and then
```
eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)";
```
before `brew test-bot...`.

