### PR TITLE
circle.yml: $HOME -> /home/ubuntu

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ test:
   override:
     - umask 022;
       PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH";
-      eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib)";
+      eval "$(perl -I/home/ubuntu/perl5/lib/perl5 -Mlocal::lib)";
       brew install patchelf
         && brew tap homebrew/dupes
         && brew tap linuxbrew/xorg


### PR DESCRIPTION
CircleCI uses docker image with user 'ubuntu'. When we install CPAN modules using local::lib, we use ubuntu's home folder, that is `/home/ubuntu`. As a result, when we use `eval ...` we have to use `/home/ubuntu` instead of `$HOME`