### PR TITLE
lua: add liblua.so for linux

### DIFF
--- a/Formula/lua.rb
+++ b/Formula/lua.rb
@@ -30,6 +30,12 @@ class Lua < Formula
   # See: https://github.com/Homebrew/homebrew/pull/5043
   patch :DATA if OS.mac?
 
+  # Add shared library for linux
+  patch do
+    url "https://gist.githubusercontent.com/wangpeiwen/c897bbe731dfcaa3cafb97af1ba58342/raw/cf7aea1ea6cb904975758aa66e0488ce2b7679da/lua.patch"
+    sha256 "82a7781c37afc6f8363a8c62c691a4fc64072201366a2fc8c9879092ac4e40fb"
+  end if OS.linux?
+
   # completion provided by advanced readline power patch
   # See http://lua-users.org/wiki/LuaPowerPatches
   if build.with? "completion"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
see [http://stackoverflow.com/questions/20848275/compiling-lua-create-so-files](http://stackoverflow.com/questions/20848275/compiling-lua-create-so-files) #1390 
I add a liblua.so with `-fPIC`
and keep liblua.a without `-fPIC`