### PR TITLE
scriptcs: Fix for Linuxbrew

### DIFF
--- a/Formula/scriptcs.rb
+++ b/Formula/scriptcs.rb
@@ -24,7 +24,7 @@ class Scriptcs < Formula
 
   def install
     script_file = "scriptcs.sh"
-    system "sh", "./build_brew.sh"
+    system "bash", "./build_brew.sh"
     libexec.install Dir["src/ScriptCs/bin/Release/*"]
     (libexec/script_file).write <<-EOS.undent
       #!/bin/bash


### PR DESCRIPTION
build_brew.sh contains bashisms, but is invoked with sh.
This is a problem on Ubuntu, because sh is dash, not bash as
on macOS.

Fix error:
./build_brew.sh: 3: set: Illegal option -o pipefail

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
