### PR TITLE
numpy and scipy: Add OpenBLAS support

### DIFF
--- a/Formula/numpy.rb
+++ b/Formula/numpy.rb
@@ -21,10 +21,12 @@ class Numpy < Formula
   end
 
   option "without-python", "Build without python2 support"
+  option "with-openblas", "Use OpenBLAS instead of Apple's Accelerate Framework"
 
   depends_on :fortran => :build
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
   depends_on :python3 => :optional
+  depends_on "homebrew/science/openblas" => (OS.mac? ? :optional : :recommended)
 
   resource "nose" do
     url "https://files.pythonhosted.org/packages/58/a5/0dc93c3ec33f4e281849523a5a913fa1eea9a3068acfa754d44d88107a44/nose-1.3.7.tar.gz"
@@ -32,6 +34,29 @@ class Numpy < Formula
   end
 
   def install
+    # https://github.com/numpy/numpy/issues/4203
+    # https://github.com/Homebrew/homebrew-python/issues/209
+    if OS.linux?
+      ENV.append "LDFLAGS", "-shared"
+      ENV.append "FFLAGS", "-fPIC"
+    end
+
+    if build.with? "openblas"
+      openblas_dir = Formula["openblas"].opt_prefix
+      # Setting ATLAS to None is important to prevent numpy from always
+      # linking against Accelerate.framework.
+      ENV["ATLAS"] = "None"
+      ENV["BLAS"] = ENV["LAPACK"] = "#{openblas_dir}/lib/libopenblas.dylib"
+
+      config = <<-EOS.undent
+        [openblas]
+        libraries = openblas
+        library_dirs = #{openblas_dir}/lib
+        include_dirs = #{openblas_dir}/include
+      EOS
+      (buildpath/"site.cfg").write config
+    end
+
     Language::Python.each_python(build) do |python, version|
       dest_path = lib/"python#{version}/site-packages"
       dest_path.mkpath

--- a/Formula/scipy.rb
+++ b/Formula/scipy.rb
@@ -13,27 +13,57 @@ class Scipy < Formula
 
   option "without-python", "Build without python2 support"
 
-  depends_on "swig" => :build
+  depends_on :fortran
   depends_on :python => :recommended if MacOS.version <= :snow_leopard
   depends_on :python3 => :optional
-  depends_on :fortran
+  depends_on "swig" => :build
+
+  option "with-openblas", "Use OpenBLAS instead of Apple's Accelerate framework"
+  depends_on "homebrew/science/openblas" => (OS.mac? ? :optional : :recommended)
 
   numpy_options = []
   numpy_options << "with-python3" if build.with? "python3"
+  numpy_options << "with-openblas" if build.with? "openblas"
   depends_on "numpy" => numpy_options
 
   cxxstdlib_check :skip
 
   # https://github.com/Homebrew/homebrew-python/issues/110
   # There are ongoing problems with gcc+accelerate.
-  fails_with :gcc
+  fails_with :gcc if OS.mac? && build.without?("openblas")
 
   def install
+    # https://github.com/numpy/numpy/issues/4203
+    # https://github.com/Homebrew/homebrew-python/issues/209
+    # https://github.com/Homebrew/homebrew-python/issues/233
+    if OS.linux?
+      ENV.append "FFLAGS", "-fPIC"
+      ENV.append "LDFLAGS", "-shared"
+    end
+
     config = <<-EOS.undent
       [DEFAULT]
       library_dirs = #{HOMEBREW_PREFIX}/lib
       include_dirs = #{HOMEBREW_PREFIX}/include
     EOS
+    if build.with? "openblas"
+      # For maintainers:
+      # Check which BLAS/LAPACK numpy actually uses via:
+      # xcrun otool -L $(brew --prefix)/Cellar/scipy/<version>/lib/python2.7/site-packages/scipy/linalg/_flinalg.so
+      # or the other .so files.
+      openblas_dir = Formula["openblas"].opt_prefix
+      # Setting ATLAS to None is important to prevent numpy from always
+      # linking against Accelerate.framework.
+      ENV["ATLAS"] = "None"
+      ENV["BLAS"] = ENV["LAPACK"] = "#{openblas_dir}/lib/libopenblas.dylib"
+
+      config << <<-EOS.undent
+        [openblas]
+        libraries = openblas
+        library_dirs = #{openblas_dir}/lib
+        include_dirs = #{openblas_dir}/include
+      EOS
+    end
 
     Pathname("site.cfg").write config
 


### PR DESCRIPTION
`numpy` and `scipy` that have been imported to [homebrew/homebrew-core](https://github.com/homebrew/homebrew-core) dropped support for OpenBLAS (See https://github.com/Homebrew/homebrew-core/issues/9580). On linux systems without a standardized BLAS/LAPACK library, OpenBLAS support is crucial. I've brought back the `openblas` option from the formulae in [homebrew/homebrew-python](https://github.com/homebrew/homebrew-python).