### PR TITLE
numpy and scipy: OpenBLAS support

### DIFF
--- a/Formula/scipy.rb
+++ b/Formula/scipy.rb
@@ -18,6 +18,8 @@ class Scipy < Formula
   depends_on :python3 => :optional
   depends_on :fortran
 
+  depends_on "homebrew/science/openblas" unless OS.mac?
+
   numpy_options = []
   numpy_options << "with-python3" if build.with? "python3"
   depends_on "numpy" => numpy_options
@@ -26,9 +28,17 @@ class Scipy < Formula
 
   # https://github.com/Homebrew/homebrew-python/issues/110
   # There are ongoing problems with gcc+accelerate.
-  fails_with :gcc
+  fails_with :gcc if OS.mac?
 
   def install
+    # https://github.com/numpy/numpy/issues/4203
+    # https://github.com/Homebrew/homebrew-python/issues/209
+    # https://github.com/Homebrew/homebrew-python/issues/233
+    if OS.linux?
+      ENV.append "FFLAGS", "-fPIC"
+      ENV.append "LDFLAGS", "-shared"
+    end
+
     config = <<-EOS.undent
       [DEFAULT]
       library_dirs = #{HOMEBREW_PREFIX}/lib


### PR DESCRIPTION
`numpy` and `scipy` that have been imported to [homebrew/homebrew-core](https://github.com/homebrew/homebrew-core) dropped support for OpenBLAS (See https://github.com/Homebrew/homebrew-core/issues/9580). On linux systems without a standardized BLAS/LAPACK library, OpenBLAS support is crucial. I've brought back the `openblas` option from the formulae in [homebrew/homebrew-python](https://github.com/homebrew/homebrew-python).