### PR TITLE
nss: fix heinous os specific install logic

### DIFF
--- a/Formula/nss.rb
+++ b/Formula/nss.rb
@@ -43,7 +43,7 @@ class Nss < Formula
     # rather than copying the referenced file.
     cd "../dist"
     bin.mkpath
-    Dir.glob("Darwin*/bin/*") do |file|
+    Dir.glob("*.OBJ/bin/*") do |file|
       cp file, bin unless file.include? ".dylib"
     end
 
@@ -53,7 +53,7 @@ class Nss < Formula
 
     lib.mkpath
     libexec.mkpath
-    Dir.glob("Darwin*/lib/*") do |file|
+    Dir.glob("*.OBJ/lib/*") do |file|
       if file.include? ".chk"
         cp file, libexec
       else

--- a/Formula/nss.rb
+++ b/Formula/nss.rb
@@ -19,6 +19,7 @@ class Nss < Formula
   EOS
 
   depends_on "nspr"
+  depends_on "sqlite"
 
   def install
     ENV.deparallelize

--- a/Formula/nss.rb
+++ b/Formula/nss.rb
@@ -20,6 +20,7 @@ class Nss < Formula
 
   depends_on "nspr"
   depends_on "sqlite"
+  depends_on "zlib" unless OS.mac?
 
   def install
     ENV.deparallelize


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Audit complains about .chk files being installed to /lib.

```
% brew audit --strict nss
nss:
  * Non-libraries were installed to "brew/opt/nss/lib"
    Installing non-libraries to "lib" is discouraged.
    The offending files are:
      brew/opt/nss/lib/libfreebl3.chk
      brew/opt/nss/lib/libnssdbm3.chk
      brew/opt/nss/lib/libfreeblpriv3.chk
      brew/opt/nss/lib/libsoftokn3.chk
Error: 1 problem in 1 formula
```
Debian has the following setup. What should Linuxbrew do?

```
/usr/lib/x86_64-linux-gnu/libnss3.so
/usr/lib/x86_64-linux-gnu/libnssutil3.so
/usr/lib/x86_64-linux-gnu/libsmime3.so
/usr/lib/x86_64-linux-gnu/libssl3.so
/usr/lib/x86_64-linux-gnu/nss/libfreebl3.chk
/usr/lib/x86_64-linux-gnu/nss/libfreebl3.so
/usr/lib/x86_64-linux-gnu/nss/libnssckbi.so
/usr/lib/x86_64-linux-gnu/nss/libnssdbm3.chk
/usr/lib/x86_64-linux-gnu/nss/libnssdbm3.so
/usr/lib/x86_64-linux-gnu/nss/libsoftokn3.chk
/usr/lib/x86_64-linux-gnu/nss/libsoftokn3.so
/usr/share/doc/libnss3/changelog.Debian.gz
/usr/share/doc/libnss3/copyright
/usr/share/lintian/overrides/libnss3
```

Adressese issue #1620 