### PR TITLE
libunwind: Remove dependency on xz for Linuxbrew

### DIFF
--- a/Formula/libunwind.rb
+++ b/Formula/libunwind.rb
@@ -1,12 +1,13 @@
 class Libunwind < Formula
   desc "C API for determining the call-chain of a program"
   homepage "http://www.nongnu.org/libunwind/"
-  url "http://download.savannah.gnu.org/releases/libunwind/libunwind-1.1.tar.gz"
+  url "https://download.savannah.gnu.org/releases/libunwind/libunwind-1.1.tar.gz"
   sha256 "9dfe0fcae2a866de9d3942c66995e4b460230446887dbdab302d41a8aee8d09a"
+  revision 1
   head "git://git.sv.gnu.org/libunwind.git"
   # tag "linuxbrew"
 
-  depends_on "xz"
+  depends_on "xz" => :optional
 
   bottle do
     sha256 "caabeb18f79a24a02caf5c3f706c144173310410bddd470160909b3eda391a41" => :x86_64_linux
@@ -14,7 +15,8 @@ class Libunwind < Formula
 
   def install
     system "./configure", "--prefix=#{prefix}",
-      "--disable-debug", "--disable-dependency-tracking", "--disable-silent-rules"
+      "--disable-debug", "--disable-dependency-tracking", "--disable-silent-rules",
+      *("--enable-minidebuginfo" if build.with? "xz")
     system "make", "install"
   end
 

--- a/circle.yml
+++ b/circle.yml
@@ -35,8 +35,8 @@ test:
       brew install patchelf
         && brew tap homebrew/dupes
         && brew tap linuxbrew/xorg
-        && brew test-bot --tap=homebrew/core --keep-old
+        && brew test-bot --tap=homebrew/core
     - mv *.json *.tar.gz $CIRCLE_ARTIFACTS/ || true
 notify:
   webhooks:
-    - url: https://p4142ivuwk.execute-api.us-west-2.amazonaws.com/prod/LinuxbrewTestBot?keep-old=1
+    - url: https://p4142ivuwk.execute-api.us-west-2.amazonaws.com/prod/LinuxbrewTestBot


### PR DESCRIPTION
`xz` appears to be an optional dependency of `libunwind`.