### PR TITLE
ripgrep: fix for linuxbrew

### DIFF
--- a/Formula/ripgrep.rb
+++ b/Formula/ripgrep.rb
@@ -11,7 +11,9 @@ class Ripgrep < Formula
     sha256 "ab72bd1f61995d0c2000db95c84bd08d4d6959639cf8c0693be51ef76d62aab0" => :yosemite
   end
 
-  depends_on "rust" => :build
+  # rust broken on linux: https://github.com/Linuxbrew/homebrew-core/issues/1733
+  # install using command line in https://www.rust-lang.org/en-US/install.html
+  # depends_on "rust" => :build
 
   def install
     system "cargo", "build", "--release"

--- a/Formula/ripgrep.rb
+++ b/Formula/ripgrep.rb
@@ -16,9 +16,9 @@ class Ripgrep < Formula
   # depends_on "rust" => :build
 
   def install
+    # NOTE: requires `export RUSTUP_HOME=$HOME/.multirust` before calling `brew install ripgrep`
     # without this, error: no default toolchain configured because $HOME=/tmp/ripgrep-.../ripgrep-0.4.0/.brew_home
-    # TODO: how to get $HOME without hardcoding or passing an env var $RUSTUP_HOME to brew?
-    system 'export RUSTUP_HOME=/home/timothee/.multirust && cargo build --release'
+    system "cargo", "build", "--release"
 
     bin.install "target/release/rg"
     man1.install "doc/rg.1"

--- a/Formula/ripgrep.rb
+++ b/Formula/ripgrep.rb
@@ -16,7 +16,9 @@ class Ripgrep < Formula
   # depends_on "rust" => :build
 
   def install
-    system "cargo", "build", "--release"
+    # without this, error: no default toolchain configured because $HOME=/tmp/ripgrep-.../ripgrep-0.4.0/.brew_home
+    # TODO: how to get $HOME without hardcoding or passing an env var $RUSTUP_HOME to brew?
+    system 'export RUSTUP_HOME=/home/timothee/.multirust && cargo build --release'
 
     bin.install "target/release/rg"
     man1.install "doc/rg.1"


### PR DESCRIPTION
FYI @sjackman  

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

* doesn't pass audit yet (WIP): Commented-out dep "rust" => :build

* ripgrep depends on `rust => :build` which is broken on linuxbrew (see https://github.com/Linuxbrew/homebrew-core/issues/1733 and https://github.com/Linuxbrew/homebrew-core/pull/1744)

* furthermore, building rust takes 40 minutes to build (https://github.com/Homebrew/homebrew-core/issues/9703), so would be good to allow a user-built version of rust to avoid this slow build, at least as an option

This PR allows using a user defined version of rust (eg installed via https://www.rust-lang.org/en-US/install.html running `curl https://sh.rustup.rs -sSf | sh`). cargo installs ok:
```
which cargo
/home/timothee/.cargo/bin/cargo
```

However, I'm running into another issue:

```
brew install --keep-tmp --verbose ripgrep
==> cargo build --release
error: no default toolchain configured

Temporary files retained at /tmp/ripgrep-20170210-9397-50vknw
```

this is weird because:

```
cd /tmp/ripgrep-20170210-9397-50vknw
cd ripgrep-0.4.0
cargo build --release
# installs rg correctly:
./target/release/rg -h
#works
```

Questions:

* Q1 how do I change the PR to allow depending on rust but not building if cargo is in PATH?

* Q2  how come `cargo build --release` fails in brew but succeeds in the tmp-dir, and how do I fix it? i also tried with `--env=std` or `--env=super` (and passing the full path to cargo) but didn't help

