### PR TITLE
Freeimage: unzip build dependency

### DIFF
--- a/Formula/freeimage.rb
+++ b/Formula/freeimage.rb
@@ -1,7 +1,7 @@
 class FreeimageHttpDownloadStrategy < CurlDownloadStrategy
   def stage
     # need to convert newlines or patch chokes
-    quiet_safe_system "/usr/bin/unzip", { :quiet_flag => "-qq" }, "-aa", cached_location
+    quiet_safe_system "#{Formula["unzip"].bin}/unzip", { :quiet_flag => "-qq" }, "-aa", cached_location
     chdir
   end
 end
@@ -24,6 +24,8 @@ class Freeimage < Formula
   end
 
   option :universal
+
+  depends_on "unzip" => :build if OS.linux?
 
   patch :DATA if OS.mac?
 


### PR DESCRIPTION
  * The download scheme requires unzip which is not installed
    by default.  Added a build dependency to install unzip and
    modified download scheme to use brewed unzip

References Homebrew/homebrew-core#9846

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Per MOD instruction in Homebrew/homebrew-core#9846, the `brew audit` fixes are in Homebrew/hombrew-core#9849 and will be brought to Linuxbrew through the weekly merge hence they are not duplicated in this PR.  This PR only addresses the Linuxbrew Freeimage install bug.