### PR TITLE
rust: Depends on python for Linuxbrew

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -38,10 +38,12 @@ class Rust < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :run
   depends_on "llvm" => :optional
-  # Fix https://github.com/Linuxbrew/homebrew-core/issues/1733: couldn't find required command: ar
-  depends_on "binutils" => :build unless OS.mac?
   depends_on "openssl"
   depends_on "libssh2"
+  unless OS.mac?
+    depends_on "binutils" => :build unless OS.mac?
+    depends_on :python unless OS.mac?
+  end
 
   conflicts_with "multirust", :because => "both install rustc, rustdoc, cargo, rust-lldb, rust-gdb"
 


### PR DESCRIPTION
Fix error:
configure: error: CFG_PYTHON needed,
but unable to find any of: python2.7 python2 python

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See https://github.com/Linuxbrew/homebrew-core/pull/1744#issuecomment-279196489