### PR TITLE
valgrind: depend on binutils if gcc is installed

### DIFF
--- a/Formula/valgrind.rb
+++ b/Formula/valgrind.rb
@@ -35,6 +35,7 @@ class Valgrind < Formula
   # https://bugs.kde.org/show_bug.cgi?id=365327#c2
   # https://github.com/Homebrew/homebrew-core/pull/6231#issuecomment-255779374
   depends_on MaximumMacOSRequirement => :el_capitan
+  depends_on "binutils" => :build if Formula["gcc"].installed? && !OS.mac?
 
   # Valgrind needs vcpreload_core-*-darwin.so to have execute permissions.
   # See #2150 for more information.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

When `gcc` is installed, `valgrind` needs `binutils` to install. Otherwise, it fails with:
```log
configure:3701: checking whether the C compiler works
configure:3723: /home/linuxbrew/.linuxbrew/bin/gcc-5  -isystem/home/linuxbrew/.linuxbrew/include -L/home/linuxbrew/.linuxbrew/lib -Wl,--dynamic-linker=/home/linuxbrew/.linuxbrew/lib/ld.so -Wl,-rpath,/home/linuxbrew/.linuxbrew/lib conftest.c  >&5
/usr/bin/ld: /home/linuxbrew/.linuxbrew/lib/../lib64/crti.o: unrecognized relocation (0x2a) in section `.init'
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
```
