### PR TITLE
rust: fix bootstrap version

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -64,7 +64,7 @@ class Rust < Formula
       url "https://s3.amazonaws.com/rust-lang-ci/cargo-builds/fbeea902d2c9a5be6d99cc35681565d8f7832592/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz"
       # From:
       # name=cargo-nightly-x86_64-unknown-linux-gnu && tar -zxvf $name.tar.gz $name/version && cat $name/version
-      version "2016-12-15"
+      version "2016-12-15b"
       sha256 "0e052514ee88f236153a0d6c6f38f66d691eb4cf1ac09e6040d96e5101d57800"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
All the context given here: https://github.com/Linuxbrew/homebrew-core/pull/1744#issuecomment-279344655

@ilovezfs EDIT: after ~40m rust successfully installed with this fix (even on a machine with a previously wrong install, ie if a user had attempted `brew install rust` before https://github.com/Linuxbrew/homebrew-core/pull/1744)!
