### PR TITLE
Travis and Circle: Remove libgdbm-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
       libblas-dev
       libbz2-dev
       libfreetype6-dev
+      libgdbm-dev
       libicu-dev
       libidn11-dev
       libjasper-dev

--- a/circle.yml
+++ b/circle.yml
@@ -26,6 +26,7 @@ dependencies:
         libblas-dev
         libbz2-dev
         libfreetype6-dev
+        libgdbm-dev
         libicu-dev
         libidn11-dev
         libjasper-dev


### PR DESCRIPTION
This should prevent bad linkage for python and python3.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?