### PR TITLE
libxkbcommon: Build a bottle for Linuxbrew

### DIFF
--- a/Formula/libxkbcommon.rb
+++ b/Formula/libxkbcommon.rb
@@ -21,6 +21,7 @@ class Libxkbcommon < Formula
   depends_on :x11
   depends_on "bison" => :build
   depends_on "pkg-config" => :build
+  depends_on "linuxbrew/xorg/xkeyboardconfig" unless OS.mac?
 
   def install
     system "./autogen.sh" if build.head?

--- a/Formula/libxkbcommon.rb
+++ b/Formula/libxkbcommon.rb
@@ -25,13 +25,15 @@ class Libxkbcommon < Formula
 
   def install
     system "./autogen.sh" if build.head?
-    inreplace "configure" do |s|
-      s.gsub! "-version-script $output_objdir/$libname.ver", ""
-      s.gsub! "$wl-version-script", ""
-    end
-    inreplace %w[Makefile.in Makefile.am] do |s|
-      s.gsub! "-Wl,--version-script=${srcdir}/xkbcommon.map", ""
-      s.gsub! "-Wl,--version-script=${srcdir}/xkbcommon-x11.map", ""
+    if OS.mac?
+      inreplace "configure" do |s|
+        s.gsub! "-version-script $output_objdir/$libname.ver", ""
+        s.gsub! "$wl-version-script", ""
+      end
+      inreplace %w[Makefile.in Makefile.am] do |s|
+        s.gsub! "-Wl,--version-script=${srcdir}/xkbcommon.map", ""
+        s.gsub! "-Wl,--version-script=${srcdir}/xkbcommon-x11.map", ""
+      end
     end
 
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
Note to @maxim-belkin: as soon as this is merged, we're going to want to change `qt5` to reference the core `libxkbcommon` instead of the one from homebrew/x11.