### PR TITLE
bear: remove rpath

### DIFF
--- a/Formula/bear.rb
+++ b/Formula/bear.rb
@@ -15,11 +15,20 @@ class Bear < Formula
 
   depends_on :python if MacOS.version <= :snow_leopard
   depends_on "cmake" => :build
+  depends_on "patchelf" => :build if OS.linux?
 
   def install
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"
+    end
+  end
+
+  def post_install
+    if OS.linux?
+      # linuxbrew will add rpath to binary remove it
+      system "#{Formula["patchelf"].bin}/patchelf", "--remove-rpath",
+          "#{prefix}/#{Hardware::CPU.is_64_bit? ? "lib64":"lib"}/libear.so"
     end
   end
 


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
bear generate compiling database by preload library.
and brewed library has rpath to `$HOME/.linuxbrew/lib` usually.
when brewed glibc installed `bear foo` will break as follow.
```bash
$  bear make
make: /lib64/libc.so.6: version `GLIBC_2.14' not found (required by /data/home/okhowang/.linuxbrew/lib/libpthread.so.0)
```
because `libear.so` load brewed `libpthread.so` which depend brewed `libc.so`
and system's binary load system's libc.so which is conflict.

and `bear foo` which foo is brewed also tested.