### PR TITLE
ftgl: fix for Linuxbrew

### DIFF
--- a/Formula/ftgl.rb
+++ b/Formula/ftgl.rb
@@ -13,6 +13,7 @@ class Ftgl < Formula
   end
 
   depends_on "freetype"
+  depends_on "linuxbrew/xorg/glu" unless OS.mac?
 
   def install
     # If doxygen is installed, the docs may still fail to build.
@@ -24,7 +25,8 @@ class Ftgl < Formula
                           "--disable-freetypetest",
                           # Skip building the example program by failing to find GLUT (MacPorts)
                           "--with-glut-inc=/dev/null",
-                          "--with-glut-lib=/dev/null"
+                          "--with-glut-lib=/dev/null",
+                          OS.mac? ? "" : "--with-gl-inc=#{Formula["linuxbrew/xorg/glu"].opt_include}"
 
     system "make", "install"
   end


### PR DESCRIPTION
Fixes:
configure: error: GL/gl.h or OpenGL/gl.h is needed, please specify its location with --with-gl-inc.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
