### PR TITLE
libxkbcommon.rb: fix for Linuxbrew

### DIFF
--- a/Formula/libxkbcommon.rb
+++ b/Formula/libxkbcommon.rb
@@ -18,8 +18,10 @@ class Libxkbcommon < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on :x11
-  depends_on "bison" => :build
+  if OS.mac?
+    depends_on :x11
+    depends_on "bison" => :build
+  end
   depends_on "pkg-config" => :build
   depends_on "linuxbrew/xorg/xkeyboardconfig" unless OS.mac?
   depends_on "linuxbrew/xorg/libxcb" unless OS.mac?

--- a/Formula/libxkbcommon.rb
+++ b/Formula/libxkbcommon.rb
@@ -21,16 +21,20 @@ class Libxkbcommon < Formula
   depends_on :x11
   depends_on "bison" => :build
   depends_on "pkg-config" => :build
+  depends_on "linuxbrew/xorg/xkeyboardconfig" unless OS.mac?
+  depends_on "linuxbrew/xorg/libxcb" unless OS.mac?
 
   def install
     system "./autogen.sh" if build.head?
-    inreplace "configure" do |s|
-      s.gsub! "-version-script $output_objdir/$libname.ver", ""
-      s.gsub! "$wl-version-script", ""
-    end
-    inreplace %w[Makefile.in Makefile.am] do |s|
-      s.gsub! "-Wl,--version-script=${srcdir}/xkbcommon.map", ""
-      s.gsub! "-Wl,--version-script=${srcdir}/xkbcommon-x11.map", ""
+    if OS.mac?
+      inreplace "configure" do |s|
+        s.gsub! "-version-script $output_objdir/$libname.ver", ""
+        s.gsub! "$wl-version-script", ""
+      end
+      inreplace %w[Makefile.in Makefile.am] do |s|
+        s.gsub! "-Wl,--version-script=${srcdir}/xkbcommon.map", ""
+        s.gsub! "-Wl,--version-script=${srcdir}/xkbcommon-x11.map", ""
+      end
     end
 
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
Related to #1800

For some reason, Circle doesn't install `xkeyboardconfig` in PR 1800.
`xkeyboardconfig` is necessary for libxkbcommon to pass the tests.
`libxcb` is necessaty to build 'libxkbcommon-x11.so'