### PR TITLE
qt5: Depend on core libxkbcommon

### DIFF
--- a/Formula/qt5.rb
+++ b/Formula/qt5.rb
@@ -71,7 +71,7 @@ class Qt5 < Formula
     depends_on "pulseaudio"
     depends_on "sqlite"
     depends_on "systemd"
-    depends_on "homebrew/x11/libxkbcommon"
+    depends_on "libxkbcommon"
   end
 
   def install


### PR DESCRIPTION
It was moved from homebrew/x11.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
