### PR TITLE
qt@5.7: Fix for Linuxbrew

### DIFF
--- a/Formula/qt@5.7.rb
+++ b/Formula/qt@5.7.rb
@@ -53,6 +53,18 @@ class QtAT57 < Formula
     sha256 "48ff18be2f4050de7288bddbae7f47e949512ac4bcd126c2f504be2ac701158b"
   end
 
+  unless OS.mac?
+    depends_on :x11
+    depends_on "fontconfig"
+    depends_on "glib"
+    depends_on "icu4c"
+    depends_on "libproxy"
+    depends_on "pulseaudio"
+    depends_on "sqlite"
+    depends_on "systemd"
+    depends_on "libxkbcommon"
+  end
+
   def install
     args = %W[
       -verbose
@@ -65,9 +77,15 @@ class QtAT57 < Formula
       -qt-freetype
       -qt-pcre
       -nomake tests
-      -no-rpath
       -pkg-config
     ]
+
+    if OS.mac?
+      args << "-no-rpath"
+    elsif OS.linux?
+      args << "-qt-xcb"
+      args << "-R#{lib}"
+    end
 
     args << "-nomake" << "examples" if build.without? "examples"
 


### PR DESCRIPTION
Apply the same changes we applied to normal qt5 formula.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Closes #1844 