### PR TITLE
ios-deploy: requires macOS

### DIFF
--- a/Formula/ios-deploy.rb
+++ b/Formula/ios-deploy.rb
@@ -14,6 +14,7 @@ class IosDeploy < Formula
 
   depends_on :xcode => :build
   depends_on :macos => :yosemite
+  depends_on :macos
 
   def install
     xcodebuild "-configuration", "Release", "SYMROOT=build"


### PR DESCRIPTION
It says so in the README, fails if you try to install it through npm,
and only builds with XCode.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
