### PR TITLE
sbjson: requires macOS

### DIFF
--- a/Formula/sbjson.rb
+++ b/Formula/sbjson.rb
@@ -14,6 +14,7 @@ class Sbjson < Formula
   end
 
   depends_on :xcode => :build
+  depends_on :macos
 
   def install
     xcodebuild "-project", "SBJson5.xcodeproj",


### PR DESCRIPTION
There's no mechanism to build on Linux and it appears to only support
Apple platforms.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

Closes #1522 

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?