### PR TITLE
guile: devel and head depend on flex for Linuxbrew

### DIFF
--- a/Formula/guile.rb
+++ b/Formula/guile.rb
@@ -41,6 +41,7 @@ class Guile < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "gettext" => :build
+    depends_on "flex" => :build unless OS.mac?
 
     # Avoid undeclared identifier errors for SOCK_CLOEXEC and SOCK_NONBLOCK
     # Reported 19 Feb 2017 https://debbugs.gnu.org/cgi/bugreport.cgi?bug=25790
@@ -53,6 +54,7 @@ class Guile < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "gettext" => :build
+    depends_on "flex" => :build unless OS.mac?
   end
 
   depends_on "pkg-config" => :run # guile-config is a wrapper around pkg-config.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Following up on @maxim-belkin's [comment](https://github.com/Linuxbrew/homebrew-core/pull/1834#issuecomment-281439277) on #1834. I can reproduce the same experience with `test-bot-docker`.