### PR TITLE
systemd: Fix for gperf 3.1 for Linuxbrew

### DIFF
--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -3,6 +3,7 @@ class Systemd < Formula
   homepage "https://wiki.freedesktop.org/www/Software/systemd/"
   url "http://www.freedesktop.org/software/systemd/systemd-221.tar.xz"
   sha256 "085e088650afbfc688ccb13459aedb1fbc7c8810358605b076301f472d51cc4f"
+  revision 1
   # tag "linuxbrew"
 
   bottle do
@@ -18,6 +19,16 @@ class Systemd < Formula
   depends_on "util-linux" # for libmount
   depends_on "coreutils" => :build
   depends_on "XML::Parser" => :perl
+
+  env :super
+
+  stable do
+    # Fix error: conflicting types for 'lookup_arphrd'
+    patch do
+      url "https://github.com/systemd/systemd-stable/commit/79a5d862a7abe903f456a75d6d1ca3c11adfa379.patch"
+      sha256 "cdb6e9c7858fe24f402ea4371ed75d889f3359c741cceb7d087241706e5b85d4"
+    end
+  end
 
   def install
     system "./configure",

--- a/circle.yml
+++ b/circle.yml
@@ -55,8 +55,8 @@ test:
       brew install patchelf
         && brew tap homebrew/dupes
         && brew tap linuxbrew/xorg
-        && brew test-bot --tap=homebrew/core --keep-old
+        && brew test-bot --tap=homebrew/core
     - mv *bottle*.json *.tar.gz $CIRCLE_ARTIFACTS/ || true
 notify:
   webhooks:
-    - url: https://p4142ivuwk.execute-api.us-west-2.amazonaws.com/prod/LinuxbrewTestBot?keep-old=1
+    - url: https://p4142ivuwk.execute-api.us-west-2.amazonaws.com/prod/LinuxbrewTestBot


### PR DESCRIPTION
Fix the error: conflicting types for 'lookup_arphrd'