### PR TITLE
WIP: rust: link cargobootstrap resource against brew libc for older systems

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -88,6 +88,11 @@ class Rust < Formula
 
     resource("cargobootstrap").stage do
       system "./install.sh", "--prefix=#{buildpath}/cargobootstrap"
+      if OS.linux? and Formula["glibc"].installed?
+        keg = Keg.new(prefix)
+        file = Pathname.new('#{buildpath}/cargobootstrap')
+        keg.change_rpath(file, Keg::PREFIX_PLACEHOLDER, HOMEBREW_PREFIX.to_s)
+      end
     end
     ENV.prepend_path "PATH", buildpath/"cargobootstrap/bin"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
