### PR TITLE
heroku: Fix for Linuxbrew

### DIFF
--- a/Formula/heroku.rb
+++ b/Formula/heroku.rb
@@ -1,9 +1,14 @@
 class Heroku < Formula
   desc "Everything you need to get started with Heroku"
   homepage "https://cli.heroku.com"
-  url "https://cli-assets.heroku.com/branches/stable/5.6.28-2643c0a/heroku-v5.6.28-2643c0a-darwin-amd64.tar.xz"
+  if OS.mac?
+    url "https://cli-assets.heroku.com/branches/stable/5.6.28-2643c0a/heroku-v5.6.28-2643c0a-darwin-amd64.tar.xz"
+    sha256 "7d0320800410821349a0f44be1ca49619388ef934e3ae2334b7c6b1f5028da95"
+  elsif OS.linux?
+    url "https://cli-assets.heroku.com/branches/stable/5.6.28-2643c0a/heroku-v5.6.28-2643c0a-linux-amd64.tar.xz"
+    sha256 "bfc57ca6a30f55bb24ff166e489f305be8c26be22e2c9a323a73d8c2cce1a18f"
+  end
   version "5.6.28-2643c0a"
-  sha256 "7d0320800410821349a0f44be1ca49619388ef934e3ae2334b7c6b1f5028da95"
 
   bottle :unneeded
 


### PR DESCRIPTION
Download the Linux tarball.

Note that this still won't work for ARM, but at least it handles amd64.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?