### PR TITLE
flex: Install lex symlink on Linuxbrew

### DIFF
--- a/Formula/flex.rb
+++ b/Formula/flex.rb
@@ -15,8 +15,10 @@ class Flex < Formula
 
   depends_on "help2man" => :build
   depends_on "gettext"
-  depends_on "homebrew/dupes/m4" unless OS.mac?
-  depends_on "bison" => :build unless OS.mac?
+  unless OS.mac?
+    depends_on "homebrew/dupes/m4"
+    depends_on "bison" => :build
+  end
 
   def install
     system "./configure", "--disable-dependency-tracking",
@@ -24,6 +26,7 @@ class Flex < Formula
                           "--enable-shared",
                           "--prefix=#{prefix}"
     system "make", "install"
+    bin.install_symlink "flex" => "lex" unless OS.mac?
   end
 
   test do


### PR DESCRIPTION
Certain formulae, such as aamath, call lex directly instead of flex.
Note that Debian does the same.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
