### PR TITLE
libffi: fix audit for Linuxbrew

### DIFF
--- a/Formula/libffi.rb
+++ b/Formula/libffi.rb
@@ -31,7 +31,7 @@ class Libffi < Formula
     # Move lib64/* to lib/ on Linuxbrew
     lib64 = Pathname.new "#{lib}64"
     if lib64.directory?
-      system "mv #{lib64}/* #{lib}/"
+      mv Dir[lib64/"*"], lib
       rmdir lib64
     end
   end


### PR DESCRIPTION
Currently, ```brew audit --strict libffi``` returns

```
libffi:
  * Use the `mv` Ruby method instead of `system "mv `
Error: 1 problem in 1 formula
```