### PR TITLE
chezscheme: Fix for Linuxbrew

### DIFF
--- a/Formula/chezscheme.rb
+++ b/Formula/chezscheme.rb
@@ -12,6 +12,14 @@ class Chezscheme < Formula
   end
 
   depends_on :x11 => :build
+  depends_on "homebrew/dupes/ncurses" unless OS.mac?
+
+  # Fixes bashism in makefiles/installsh
+  # Remove on next release
+  patch do
+    url "https://github.com/cisco/ChezScheme/commit/6be137e5b76c6a8472e311a69743a403adc757f5.diff"
+    sha256 "098611b16ed92993cc0c31ec8510bd26c81dee38b807c3707abb646b220b5ce0"
+  end unless OS.mac?
 
   def install
     # dyld: lazy symbol binding failed: Symbol not found: _clock_gettime


### PR DESCRIPTION
Fixes a bashism in makefiles/installsh that fails on Ubuntu

Fix error: ./installsh: 64: [: 0: unexpected operator

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?