### PR TITLE
volatility: fix for linuxbrew

### DIFF
--- a/Formula/volatility.rb
+++ b/Formula/volatility.rb
@@ -168,7 +168,7 @@ class Volatility < Formula
     res = resources.map(&:name).to_set - ["Pillow"]
 
     res.each do |r|
-      venv.pip_install resource(r)
+      venv.pip_install resource(r) unless r == "appnope"
     end
 
     venv.pip_install_and_link buildpath


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Currently, Appnope will refuse to install on anything but Mac OSX.

I have thought about creating an array called MAC_SPECIFIC_RES and checking for inclusion instead of explicitly excluding appnope, to allow for future exclusions. But since, there is only one now, I figured it would be simpler to just ignore appnope for now, and we can always add the list method later.