### PR TITLE
scrollkeeper: Depends on libxslt for Linuxbrew

### DIFF
--- a/Formula/scrollkeeper.rb
+++ b/Formula/scrollkeeper.rb
@@ -15,6 +15,7 @@ class Scrollkeeper < Formula
 
   depends_on "gettext"
   depends_on "docbook"
+  depends_on "libxslt" unless OS.mac?
 
   conflicts_with "rarian",
     :because => "scrollkeeper and rarian install the same binaries."


### PR DESCRIPTION
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Discovered at https://github.com/Linuxbrew/homebrew-dupes/pull/120#issuecomment-291040389