### PR TITLE
newt: Fix for Linuxbrew

### DIFF
--- a/Formula/newt.rb
+++ b/Formula/newt.rb
@@ -14,6 +14,7 @@ class Newt < Formula
   depends_on "gettext"
   depends_on "popt"
   depends_on "s-lang"
+  depends_on :python unless OS.mac?
 
   def install
     args = ["--prefix=#{prefix}", "--without-tcl"]
@@ -30,6 +31,8 @@ class Newt < Formula
       s.gsub! "`$$pyconfig --ldflags`", '"-undefined dynamic_lookup"'
       s.gsub! "`$$pyconfig --libs`", '""'
     end if OS.mac?
+
+    inreplace "configure", "/usr/include/python", "#{HOMEBREW_PREFIX}/include/python" unless OS.mac?
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This patch should fix the Linuxbrew-installed newt's Python bindings.