### PR TITLE
gtk+3: Fix deps and test for Linuxbrew

### DIFF
--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -22,7 +22,13 @@ class Gtkx3 < Formula
   depends_on "hicolor-icon-theme"
   depends_on "gsettings-desktop-schemas" => :recommended
   depends_on "jasper" => :optional
-  depends_on "cairo" unless OS.mac?
+
+  unless OS.mac?
+    depends_on "at-spi2-atk"
+    depends_on "cairo"
+    depends_on "fontconfig"
+    depends_on "harfbuzz"
+  end
 
   def install
     args = %W[


### PR DESCRIPTION
* Depends on atk-spi-2, fontconfig, and harfbuzz
* The test used the Mac-only -lintl