### PR TITLE
x11 (new formula)

### DIFF
--- a/Formula/x11.rb
+++ b/Formula/x11.rb
@@ -1,0 +1,23 @@
+class X11 < Formula
+  desc "X.Org X11 libraries"
+  homepage "https://www.x.org/"
+  ### http://www.linuxfromscratch.org/blfs/view/svn/x/x7lib.html
+  url "https://raw.githubusercontent.com/Linuxbrew/homebrew-xorg/317ef5e60c62298a28f08bb44ca6a09d79793735/README.md"
+  version "20170115"
+  sha256 "76b4fd623d6b10d816069aedcffc411e2c9abc607533adf3fa810d7904b5f9d1"
+  # tag "linuxbrew"
+
+  bottle :unneeded
+
+  depends_on "linuxbrew/xorg/xorg"
+
+  def install
+    ohai "This is a virtual package that only exists to depend on linuxbrew/xorg/xorg"
+    prefix.install "README.md" => "x11.md"
+  end
+
+  test do
+    # No test is possible. Just silence brew audit
+    true
+  end
+end


### PR DESCRIPTION
This is a virtual package that exists only to depend on linuxbrew/xorg/xorg

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is needed by https://github.com/Linuxbrew/brew/pull/337. It serves no purpose other than to depend on `linuxbrew/xorg/xorg`.

(Ironically, `linuxbrew/xorg/xorg` itself only exists to depend on other stuff in the xorg tap!)