### PR TITLE
switchaudio-osx: Depends on macOS

### DIFF
--- a/Formula/switchaudio-osx.rb
+++ b/Formula/switchaudio-osx.rb
@@ -15,6 +15,7 @@ class SwitchaudioOsx < Formula
   end
 
   depends_on :macos => :lion
+  depends_on :macos
   depends_on :xcode => :build
 
   def install


### PR DESCRIPTION
Hard dependency on macOS API's.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
