### PR TITLE
pango: Use env :std for Linuxbrew

### DIFF
--- a/Formula/pango.rb
+++ b/Formula/pango.rb
@@ -31,6 +31,9 @@ class Pango < Formula
     depends_on :x11
   end
 
+  # Work around the error: Checking for 'cairo' >= 1.10.0: not found
+  env :std if OS.linux?
+
   def install
     args = %W[
       --disable-dependency-tracking


### PR DESCRIPTION
Work around the error: Checking for 'cairo' >= 1.10.0: not found