### PR TITLE
xhyve: Depends on macos

### DIFF
--- a/Formula/xhyve.rb
+++ b/Formula/xhyve.rb
@@ -14,6 +14,7 @@ class Xhyve < Formula
   end
 
   depends_on :macos => :yosemite
+  depends_on :macos
 
   def install
     args = []


### PR DESCRIPTION
It's a port of bhyve (a FreeBSD virtualiztion solution) for macOS
on top of Hypervisor.framework.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
