### PR TITLE
pidof: Depends on macOS

### DIFF
--- a/Formula/pidof.rb
+++ b/Formula/pidof.rb
@@ -15,6 +15,9 @@ class Pidof < Formula
     sha256 "ce5f3ea346e86cd98880ece0e457a5febfd48165ba947152bea9a3c459f41b3f" => :lion
   end
 
+  # Hard dependency on sys/proc.h, which isn't available on Linux
+  depends_on :macos
+
   def install
     system "make", "all", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}"
     man1.install gzip("pidof.1")


### PR DESCRIPTION
It has a hard dependency on <sys/proc.h>, which Linux does not provide.
Note that neither libbsd nor clens provides it either :(

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

See https://stackoverflow.com/questions/18564550/linux-gcc-proc-h-header-missing-where-is-the-proc-struct-defined . Note that this shouldn't affect `percona-server`.