### PR TITLE
minizip: fix for Linuxbrew

### DIFF
--- a/Formula/minizip.rb
+++ b/Formula/minizip.rb
@@ -15,6 +15,7 @@ class Minizip < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "zlib" unless OS.mac?
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/minizip.rb
+++ b/Formula/minizip.rb
@@ -26,7 +26,7 @@ class Minizip < Formula
         s.sub! "-L$(zlib_top_builddir)", "$(zlib_top_builddir)/libz.a"
         s.sub! "-version-info 1:0:0 -lz", "-version-info 1:0:0"
         s.sub! "libminizip.la -lz", "libminizip.la"
-      end
+      end if OS.mac?
       system "autoreconf", "-fi"
       system "./configure", "--prefix=#{prefix}"
       system "make", "install"


### PR DESCRIPTION
On Linux we do not need to link to libz.a statically. In fact, this
breaks the build.