### PR TITLE
libsigc++: Fix for Linuxbrew

### DIFF
--- a/Formula/libsigc++.rb
+++ b/Formula/libsigc++.rb
@@ -14,6 +14,8 @@ class Libsigcxx < Formula
 
   needs :cxx11
 
+  depends_on "m4" => :build unless OS.mac?
+
   def install
     ENV.cxx11
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"


### PR DESCRIPTION
Under superenv, libsigc++ fails to build with the following error message:

```
checking for gm4... no
checking for m4... no
configure: error: in `/tmp/libsigc++-20170426-7376-fvufgz/libsigc++-2.10.0':
configure: error: The GNU M4 macro processor is required for building libsigc++.
```

https://gist.github.com/48172fa5fb0c8aa9644e9bab11c386d6

This PR makes libsigc++ depend on m4 for Linuxbrew