### PR TITLE
llvm: disable assertions and use a higher optimization level

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -294,6 +294,12 @@ class Llvm < Formula
       args << "-DCLANG_DEFAULT_CXX_STDLIB=#{build.with?("libcxx")?"libc++":"libstdc++"}"
     end
 
+    args << "-DLIBUNWIND_ENABLE_ASSERTIONS=OFF"
+    args << "-DLIBCXXABI_ENABLE_ASSERTIONS=OFF"
+    args << "-DLIBCXX_ENABLE_ASSERTIONS=OFF"
+    args << "-DCMAKE_C_FLAGS_RELEASE=-DNDEBUG -Ofast"
+    args << "-DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG -Ofast"
+
     mktemp do
       if build.with? "ocaml"
         args << "-DLLVM_OCAML_INSTALL_PATH=#{lib}/ocaml"


### PR DESCRIPTION
Due to a possible upstream bug http://lists.llvm.org/pipermail/llvm-bugs/2015-March/038930.html , assertions in `libuwind`, `libcxx`, `libcxxabi` are enabled by default even if `CMAKE_BUILD_TYPE` is `Release`. This slows down clang parser significantly.

Also, linuxbrew uses the `-Os` optimization level, this also slows down the clang parser compared to the cmake default `-O3` build.

This pull request disables all the assertions and builds llvm using the `-Ofast` optimization level.
