### PR TITLE
terminal-notifier: Depends on macOS

### DIFF
--- a/Formula/terminal-notifier.rb
+++ b/Formula/terminal-notifier.rb
@@ -15,6 +15,9 @@ class TerminalNotifier < Formula
   depends_on :macos => :mountain_lion
   depends_on :xcode => :build
 
+  # https://github.com/julienXX/terminal-notifier/issues/184
+  depends_on :macos
+
   def install
     xcodebuild "-project", "Terminal Notifier.xcodeproj",
                "-target", "terminal-notifier",


### PR DESCRIPTION
Per https://github.com/julienXX/terminal-notifier/issues/184 Linux is not supported.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----