### PR TITLE
gdbm: Enable --with-libgdbm-compat by default for Linuxbrew

### DIFF
--- a/Formula/gdbm.rb
+++ b/Formula/gdbm.rb
@@ -4,16 +4,20 @@ class Gdbm < Formula
   url "https://ftp.gnu.org/gnu/gdbm/gdbm-1.13.tar.gz"
   mirror "https://ftpmirror.gnu.org/gdbm/gdbm-1.13.tar.gz"
   sha256 "9d252cbd7d793f7b12bcceaddda98d257c14f4d1890d851c386c37207000a253"
+  revision 1 if OS.linux?
 
   bottle do
     cellar :any
     sha256 "9647a01c12d0aeddfe0a73daeed3994ccc655bb61114f3be6b54bdf982d72790" => :sierra
     sha256 "f2f5f359af6a2ecb3da54e242c43e914f4a60343dc42f13380948ebc977284dc" => :el_capitan
     sha256 "1fa21ba6e4c5dc5b5d6bf9faae3f8c8e1304a95a8bd201712d40bd4271767948" => :yosemite
-    sha256 "adc2289487de3c31ff66639a27a5773242895b9f94f5fe66a3d511ba40178e73" => :x86_64_linux
   end
 
-  option "with-libgdbm-compat", "Build libgdbm_compat, a compatibility layer which provides UNIX-like dbm and ndbm interfaces."
+  if OS.mac?
+    option "with-libgdbm-compat", "Build libgdbm_compat, a compatibility layer which provides UNIX-like dbm and ndbm interfaces."
+  else
+    option "without-libgdbm-compat", "Do not build libgdbm_compat, a compatibility layer which provides UNIX-like dbm and ndbm interfaces."
+  end
 
   # Use --without-readline because readline detection is broken in 1.13
   # https://github.com/Homebrew/homebrew-core/pull/10903

--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -2,6 +2,7 @@ class Perl < Formula
   desc "Highly capable, feature-rich programming language"
   homepage "https://www.perl.org/"
   head "https://perl5.git.perl.org/perl.git", :branch => "blead"
+  revision 1 if OS.linux?
 
   stable do
     url "https://www.cpan.org/src/5.0/perl-5.24.1.tar.xz"
@@ -22,7 +23,6 @@ class Perl < Formula
     sha256 "af578c645e5ff6162b29c693c6145345fef4dfc848f9d999a6e1f36330318c63" => :sierra
     sha256 "c66b2d1daf5e4d77b8f4943b9718610c6d24d20537e6a1b6a87ccf74fd54ec02" => :el_capitan
     sha256 "3474d4c2ddf177e331d70af4dbe1f51199139e525add8424b43b6339358950ab" => :yosemite
-    sha256 "dc772c3c214b7d9c53872ab795994e4523f2a18c454b9e1717da548adb0d2ceb" => :x86_64_linux
   end
 
   option "with-dtrace", "Build with DTrace probes"
@@ -31,7 +31,7 @@ class Perl < Formula
   deprecated_option "with-tests" => "with-test"
 
   unless OS.mac?
-    depends_on "gdbm" => "with-libgdbm-compat"
+    depends_on "gdbm"
     depends_on "berkeley-db"
 
     # required for XML::Parser


### PR DESCRIPTION
perl depends on gdbm --with-libgdbm-compat.