### PR TITLE
mpg123: fix "Use CoreAudio if it's only MacOSX"

### DIFF
--- a/Formula/mpg123.rb
+++ b/Formula/mpg123.rb
@@ -5,7 +5,7 @@ class Mpg123 < Formula
   url "https://master.dl.sourceforge.net/project/mpg123/mpg123/1.24.0/mpg123-1.24.0.tar.bz2"
   mirror "https://netix.dl.sourceforge.net/project/mpg123/mpg123/1.24.0/mpg123-1.24.0.tar.bz2"
   sha256 "55fb169a7711938f5df0497d1ffe28419fbef50011dc01d00b216379e6a2256c"
-  
+
   bottle do
     cellar :any
     sha256 "f2781679463e9da849fe9fd73f57383b5d53380c1b71b600a9595b99ad28f3f1" => :sierra

--- a/Formula/mpg123.rb
+++ b/Formula/mpg123.rb
@@ -1,10 +1,11 @@
+
 class Mpg123 < Formula
   desc "MP3 player for Linux and UNIX"
-  homepage "https://www.mpg123.de/"
-  url "https://www.mpg123.de/download/mpg123-1.23.8.tar.bz2"
-  mirror "https://mpg123.orgis.org/download/mpg123-1.23.8.tar.bz2"
-  sha256 "de2303c8ecb65593e39815c0a2f2f2d91f708c43b85a55fdd1934c82e677cf8e"
-
+  homepage "https://sourceforge.net/projects/mpg123/"
+  url "https://master.dl.sourceforge.net/project/mpg123/mpg123/1.24.0/mpg123-1.24.0.tar.bz2"
+  mirror "https://netix.dl.sourceforge.net/project/mpg123/mpg123/1.24.0/mpg123-1.24.0.tar.bz2"
+  sha256 "55fb169a7711938f5df0497d1ffe28419fbef50011dc01d00b216379e6a2256c"
+  
   bottle do
     cellar :any
     sha256 "f2781679463e9da849fe9fd73f57383b5d53380c1b71b600a9595b99ad28f3f1" => :sierra

--- a/Formula/mpg123.rb
+++ b/Formula/mpg123.rb
@@ -20,7 +20,7 @@ class Mpg123 < Formula
       --with-module-suffix=.so
     ]
     args << "--with-default-audio=coreaudio" if OS.mac?
-    
+
     if MacOS.prefer_64_bit?
       args << "--with-cpu=x86-64"
     else

--- a/Formula/mpg123.rb
+++ b/Formula/mpg123.rb
@@ -17,10 +17,10 @@ class Mpg123 < Formula
       --disable-debug
       --disable-dependency-tracking
       --prefix=#{prefix}
-      --with-default-audio=coreaudio
       --with-module-suffix=.so
     ]
-
+    args << "--with-default-audio=coreaudio" if OS.mac?
+    
     if MacOS.prefer_64_bit?
       args << "--with-cpu=x86-64"
     else


### PR DESCRIPTION
Use CoreAudio if it's only MacOSX
https://github.com/Linuxbrew/homebrew-core/issues/2766

- [X] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
