### PR TITLE
boost-python: Depends on python for Linuxbrew

### DIFF
--- a/Formula/boost-python.rb
+++ b/Formula/boost-python.rb
@@ -17,6 +17,7 @@ class BoostPython < Formula
 
   depends_on :python3 => :optional
   depends_on "boost"
+  depends_on :python => :recommended unless OS.mac?
 
   def install
     # "layout" should be synchronized with boost


### PR DESCRIPTION
Fix the errors:

/usr/bin/ld: cannot find -lpython2.7

ImportError: /home/linuxbrew/.linuxbrew/lib/libboost_python.so.1.64.0:
undefined symbol: PyUnicodeUCS4_FromEncodedObject