### PR TITLE
cryptol: Depends on ncurses for Linuxbrew

### DIFF
--- a/Formula/cryptol.rb
+++ b/Formula/cryptol.rb
@@ -20,6 +20,7 @@ class Cryptol < Formula
   depends_on "ghc" => :build
   depends_on "cabal-install" => :build
   depends_on "z3" => :run
+  depends_on "ncurses" unless OS.mac?
 
   def install
     # Remove sbv constraint for > 2.4.0


### PR DESCRIPTION
Fix the error: Missing libraries: libncursesw.so.6