### PR TITLE
aws-sdk-cpp: Reduce memory usage for Circle CI for Linuxbrew

### DIFF
--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -20,7 +20,7 @@ class AwsSdkCpp < Formula
 
   def install
     # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2" if ENV["CIRCLECI"]
+    ENV["MAKEFLAGS"] = "-j1" if ENV["CIRCLECI"]
 
     args = std_cmake_args
     args << "-DSTATIC_LINKING=1" if build.with? "static"


### PR DESCRIPTION
Reduce memory usage below 4 GB for Circle CI.