### PR TITLE
--without-ada flag for ncurses

### DIFF
--- a/Formula/ncurses.rb
+++ b/Formula/ncurses.rb
@@ -48,7 +48,8 @@ class Ncurses < Formula
                           "--mandir=#{man}",
                           "--with-manpage-format=normal",
                           "--with-shared",
-                          "--with-gpm=no"
+                          "--with-gpm=no",
+                          "--without-ada"
     system "make"
     ENV.deparallelize
     system "make", "install"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Added `--without-ada` flag for `ncurses`. Since `brew`'s `gcc` does not support `ada`, installing `ncurses` will call system's `gnatlink`. While this is harmless most of the time, on older systems (e.g. `glibc 2.14`, this will fail in unexpected ways.