### PR TITLE
charm-tools: Depends on gmp for Linuxbrew

### DIFF
--- a/Formula/charm-tools.rb
+++ b/Formula/charm-tools.rb
@@ -20,7 +20,10 @@ class CharmTools < Formula
   depends_on :hg
   depends_on "charm"
   depends_on "openssl@1.1"
-  depends_on "libffi" unless OS.mac?
+  unless OS.mac?
+    depends_on "libffi"
+    depends_on "gmp" # for pycrypto
+  end
 
   # Additionally include ndg-httpsclient for requests[security]
   resource "Cheetah" do


### PR DESCRIPTION
Resource pycrypto depends on gmp.
Fix the error:
```
Unwanted system libraries:
  libgmp.so.10
```