### PR TITLE
liboping: Depends on ncurses for Linuxbrew

### DIFF
--- a/Formula/liboping.rb
+++ b/Formula/liboping.rb
@@ -10,6 +10,8 @@ class Liboping < Formula
     sha256 "c4f46d01bdace450a49e2c4fc4ba4056070bf1b869ed07f1b0a1d6a4f7646bc9" => :yosemite
   end
 
+  depends_on "ncurses" unless OS.mac?
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
The executable noping requires ncurses.