### PR TITLE
openssl: Add an http mirror for cacert.pem for Linuxbrew

### DIFF
--- a/Formula/openssl.rb
+++ b/Formula/openssl.rb
@@ -26,6 +26,7 @@ class Openssl < Formula
   resource "cacert" do
     # homepage "http://curl.haxx.se/docs/caextract.html"
     url "https://curl.haxx.se/ca/cacert-2017-01-18.pem"
+    mirror "http://cdn.rawgit.com/sjackman/e4066d2cb6b45fbb6d213e676cb109d0/raw/58964378cb5eefe96cba245ef863c57fb2b480e0/cacert-2017-01-18.pem"
     sha256 "e62a07e61e5870effa81b430e1900778943c228bd7da1259dd6a955ee2262b47"
   end
 


### PR DESCRIPTION
No need to update the bottle.