### PR TITLE
mariadb@10.1: Depends on bzip2 for Linuxbrew

### DIFF
--- a/Formula/mariadb@10.1.rb
+++ b/Formula/mariadb@10.1.rb
@@ -26,6 +26,10 @@ class MariadbAT101 < Formula
 
   depends_on "cmake" => :build
   depends_on "openssl"
+  unless OS.mac?
+    depends_on "bzip2"
+    depends_on "ncurses"
+  end
 
   def install
     # Set basedir and ldata so that mysql_install_db can find the server


### PR DESCRIPTION
Fix the error: `Unwanted system libraries: libbz2.so.1.0`

No need to update the bottle.