### PR TITLE
yle-dl: Depends on gmp for Linuxbrew

### DIFF
--- a/Formula/yle-dl.rb
+++ b/Formula/yle-dl.rb
@@ -21,6 +21,7 @@ class YleDl < Formula
   depends_on "homebrew/php/php55-mcrypt" => :optional
   depends_on "homebrew/php/php54-mcrypt" => :optional
   depends_on "homebrew/php/php53-mcrypt" => :optional
+  depends_on "gmp" # for pycrypto
 
   resource "AdobeHDS.php" do
     # NOTE: yle-dl always installs the HEAD version of AdobeHDS.php. We use a specific commit.


### PR DESCRIPTION
Resource `pycrypto` depends on `gmp`.
Fix the error: `Unwanted system libraries: libgmp.so.10`
No need to update the bottle.