### PR TITLE
imessage-ruby: Depends on macOS

### DIFF
--- a/Formula/imessage-ruby.rb
+++ b/Formula/imessage-ruby.rb
@@ -14,6 +14,7 @@ class ImessageRuby < Formula
   end
 
   depends_on :macos => :mavericks
+  depends_on :macos
 
   def install
     rake "standalone:install", "prefix=#{prefix}"


### PR DESCRIPTION
It needs both osascript and access to the iMessage service itself.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
