### PR TITLE
ncurses: add gpatch as build dependency 

### DIFF
--- a/Formula/ncurses.rb
+++ b/Formula/ncurses.rb
@@ -16,6 +16,7 @@ class Ncurses < Formula
   keg_only :provided_by_osx
 
   depends_on "pkg-config" => :build
+  depends_on "gpatch" => :build
 
   # stable rollup patch created by upstream see
   # http://invisible-mirror.net/archives/ncurses/6.0/README

--- a/Formula/ncurses.rb
+++ b/Formula/ncurses.rb
@@ -16,7 +16,7 @@ class Ncurses < Formula
   keg_only :provided_by_osx
 
   depends_on "pkg-config" => :build
-  depends_on "gpatch" => :build
+  depends_on "gpatch" => :build unless OS.mac?
 
   # stable rollup patch created by upstream see
   # http://invisible-mirror.net/archives/ncurses/6.0/README


### PR DESCRIPTION
Because for some reason `patch` isn't installed by default on all Linux systems. See  #2842 and  #2915

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Audit run on Linux Mint 18.1 but fails on openSUSE 13.2 Harlequin  with following error message:
```bash
user@host: ~/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core$ brew audit --strict ncurses
==> Installing or updating 'rubocop' gem
Fetching: rainbow-2.2.2.gem (100%)
Building native extensions.  This could take a while...
Successfully installed rainbow-2.2.2
Fetching: ast-2.3.0.gem (100%)
Successfully installed ast-2.3.0
Fetching: parser-2.4.0.0.gem (100%)
Successfully installed parser-2.4.0.0
Fetching: powerpack-0.1.1.gem (100%)
Successfully installed powerpack-0.1.1
Fetching: ruby-progressbar-1.8.1.gem (100%)
Successfully installed ruby-progressbar-1.8.1
Fetching: unicode-display_width-1.2.1.gem (100%)
Successfully installed unicode-display_width-1.2.1
Fetching: rubocop-0.47.1.gem (100%)
Successfully installed rubocop-0.47.1
7 gems installed
Error: undefined method `[]' for nil:NilClass
Please report this bug:
  https://github.com/Linuxbrew/brew/blob/master/docs/Troubleshooting.md#troubleshooting
/home/user/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1145:in `line_problems'
/home/user/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:896:in `block in audit_lines'
/home/user/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:895:in `each'
/home/user/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:895:in `each_with_index'
/home/user/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:895:in `audit_lines'
/home/user/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1241:in `block in audit'
/home/user/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1234:in `each'
/home/user/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1234:in `audit'
/home/user/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:101:in `block in audit'
/home/user/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:97:in `each'
/home/user/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/audit.rb:97:in `audit'
/home/user/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:92:in `<main>'
```
-----
