### PR TITLE
valgrind: .travis.yml: Install libc6-dbg for Linuxbrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y libxml-parser-perl libxml-sax-perl
+  - sudo apt-get install -y libc6-dbg libxml-parser-perl libxml-sax-perl
   - DEBIAN_FRONTEND=noninteractive sudo apt-get autoremove -y --purge
       libblas-dev
       libbz2-dev

--- a/Formula/valgrind.rb
+++ b/Formula/valgrind.rb
@@ -1,3 +1,4 @@
+# Test valgrind
 class Valgrind < Formula
   desc "Dynamic analysis tools (memory, debug, profiling)"
   homepage "http://www.valgrind.org/"


### PR DESCRIPTION
`brew test valgrind` requires `libc6-dbg`.
See https://github.com/Linuxbrew/homebrew-core/pull/2985