### PR TITLE
dockutil: Depends on macOS

### DIFF
--- a/Formula/dockutil.rb
+++ b/Formula/dockutil.rb
@@ -6,6 +6,8 @@ class Dockutil < Formula
 
   bottle :unneeded
 
+  depends_on :macos
+
   def install
     bin.install "scripts/dockutil"
   end


### PR DESCRIPTION
It technically installs without issue, but it's tied to the macOS dock.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
