### PR TITLE
dark-mode: Depends on macOS

### DIFF
--- a/Formula/dark-mode.rb
+++ b/Formula/dark-mode.rb
@@ -13,6 +13,7 @@ class DarkMode < Formula
 
   depends_on :macos => :el_capitan
   depends_on :xcode => :build
+  depends_on :macos
 
   def install
     system "./build"


### PR DESCRIPTION
dark-mode only builds on macOS and is inherently tied to it.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
