### PR TITLE
swiftlint: add 'depends_on :macos'

### DIFF
--- a/Formula/swiftlint.rb
+++ b/Formula/swiftlint.rb
@@ -12,6 +12,9 @@ class Swiftlint < Formula
     sha256 "d54e7f8631dc1f4e59a9d432e0a2164b63cb6df2a48a5030706761d3b4064630" => :el_capitan
   end
 
+  # Fixes the error: make: xcodebuild: Command not found
+  depends_on :macos
+
   depends_on :xcode => ["7.0", :run]
   depends_on :xcode => ["8.0", :build]
 


### PR DESCRIPTION
swiftlint is for mac OS only.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
