### PR TITLE
aws-sdk-cpp: Skip CircleCI for Linuxbrew

### DIFF
--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -1,3 +1,8 @@
+class NoCircleCIRequirement < Requirement
+  fatal true
+  satisfy { ENV["CIRCLECI"].nil? }
+end
+
 class AwsSdkCpp < Formula
   desc "AWS SDK for C++"
   homepage "https://github.com/aws/aws-sdk-cpp"
@@ -17,11 +22,9 @@ class AwsSdkCpp < Formula
 
   depends_on "cmake" => :build
   depends_on "curl" unless OS.mac?
+  depends_on NoCircleCIRequirement
 
   def install
-    # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j2" if ENV["CIRCLECI"]
-
     args = std_cmake_args
     args << "-DSTATIC_LINKING=1" if build.with? "static"
     args << "-DNO_HTTP_CLIENT=1" if build.without? "http-client"


### PR DESCRIPTION
The 4 GB memory limit of CircleCI is insufficient.