### PR TITLE
docbook2x: depends on libxslt for Linuxbrew

### DIFF
--- a/Formula/docbook2x.rb
+++ b/Formula/docbook2x.rb
@@ -3,6 +3,7 @@ class Docbook2x < Formula
   homepage "https://docbook2x.sourceforge.io/"
   url "https://downloads.sourceforge.net/docbook2x/docbook2X-0.8.8.tar.gz"
   sha256 "4077757d367a9d1b1427e8d5dfc3c49d993e90deabc6df23d05cfe9cd2fcdc45"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any_skip_relocation
@@ -14,6 +15,7 @@ class Docbook2x < Formula
   end
 
   depends_on "docbook"
+  depends_on "libxslt" unless OS.mac?
 
   def install
     inreplace "perl/db2x_xsltproc.pl", "http://docbook2x.sf.net/latest/xslt", "#{share}/docbook2X/xslt"


### PR DESCRIPTION
Also bump the revision, because somehow the bottle had its
xsltproc_program configuration wind up empty.

We could technically depend on saxon or xalan-c instead, but libxslt is
the standard for Linuxbrew.

Fix error:
/home/linuxbrew/.linuxbrew/Cellar/docbook2x/0.8.8/bin/db2x_xsltproc:
selected XSLT processor not installed

- [ ] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

I've opened https://github.com/Homebrew/homebrew-core/pull/14984 to deal with the missing test, but until it's merged that's going to be a red flag for Linuxbrew.