### PR TITLE
Merge binutils 8d4d934e6b [do not merge]

### DIFF
--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -38,6 +38,9 @@ class Binutils < Formula
     system "make"
     system "make", "install"
     bin.install_symlink "ld.gold" => "gold" if build.with? "gold"
+
+    # Reduce the size of the bottle.
+    system "strip", *Dir[bin/"*", lib/"*.a"] unless OS.mac?
   end
 
   test do

--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -11,6 +11,7 @@ class Binutils < Formula
     sha256 "ccacdbe617addcb6f41c2fba544077987ecd2dca62cf6c7884b0bfc639f99d45" => :sierra
     sha256 "7674e8693c4af0a738c721bbb530e432f5258d516a780c109c5d1ce0458e0de3" => :el_capitan
     sha256 "1b48a19196ea84d7c2d0fcfc933967b9d1596dd5f30935948ee0d5baaa9f6f65" => :yosemite
+    sha256 "77a433a64a86f48bbb0092f0fe505dc87f37edba6d39c1c0816156a92e29f545" => :x86_64_linux
   end
 
   # No --default-names option as it interferes with Homebrew builds.


### PR DESCRIPTION
Do not merge. A portable bottle for `binutils` must be built manually.
See https://github.com/Linuxbrew/brew/wiki/Build-a-portable-bottle