### PR TITLE
fontconfig: fix Automake version mismatch on build

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -55,6 +55,7 @@ class Fontconfig < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "gperf" => :build
+    depends_on "libtool" => :build
   end
 
   def install
@@ -70,7 +71,7 @@ class Fontconfig < Formula
       font_dirs << "/System/Library/Assets/com_apple_MobileAsset_Font4"
     end
 
-    system "autoreconf", "-iv" if build.head?
+    system "autoreconf", "-iv" if build.head? || !OS.mac?
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--enable-static",


### PR DESCRIPTION
Addresses #3082

Building fontconfig from source resulted in an error when building:

```
configure.ac:37: error: version mismatch.  This is Automake 1.15.1,
configure.ac:37: but the definition used by this AM_INIT_AUTOMAKE
configure.ac:37: comes from Automake 1.15.  You should recreate
configure.ac:37: aclocal.m4 with aclocal and run automake again.
```

When installing on non-macOS systems, always run `autoreconf -iv`
as first build step. Add a `:build` dependency on `libtool` on
non-macOS systems because `autoreconf` requires this.

----
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----