### PR TITLE
rocksdb: Skip CircleCI for Linuxbrew

### DIFF
--- a/Formula/rocksdb.rb
+++ b/Formula/rocksdb.rb
@@ -1,3 +1,8 @@
+class CIRequirement < Requirement
+  fatal true
+  satisfy { ENV["CIRCLECI"].nil? && ENV["TRAVIS"].nil? }
+end
+
 class Rocksdb < Formula
   desc "Embeddable, persistent key-value store for fast storage"
   homepage "http://rocksdb.org"
@@ -19,6 +24,7 @@ class Rocksdb < Formula
     depends_on "bzip2"
     depends_on "zlib"
   end
+  depends_on CIRequirement
 
   def install
     ENV.cxx11


### PR DESCRIPTION
The 4 GB memory limit of CircleCI is insufficient.