### PR TITLE
ppsspp: Skip CircleCI for Linuxbrew (#3104)

### DIFF
--- a/Formula/ppsspp.rb
+++ b/Formula/ppsspp.rb
@@ -1,3 +1,8 @@
+class CIRequirement < Requirement
+  fatal true
+  satisfy { ENV["CIRCLECI"].nil? && ENV["TRAVIS"].nil? }
+end
+
 class Ppsspp < Formula
   desc "PlayStation Portable emulator"
   homepage "https://ppsspp.org/"
@@ -21,6 +26,7 @@ class Ppsspp < Formula
   depends_on "libzip"
   depends_on "snappy"
   depends_on "ffmpeg"
+  depends_on CIRequirement
 
   def install
     args = std_cmake_args


### PR DESCRIPTION
The 4 GB memory limit of CircleCI is insufficient.