### PR TITLE
mruby-cli: Depends on bison (build) for Linuxbrew

### DIFF
--- a/Formula/mruby-cli.rb
+++ b/Formula/mruby-cli.rb
@@ -11,6 +11,8 @@ class MrubyCli < Formula
     sha256 "a06806ca6a22d3b015e073a984e832013f2efe729870e2aa6d0b17e91a4b9855" => :yosemite
   end
 
+  depends_on "bison" => :build unless OS.mac?
+
   def install
     ENV["MRUBY_CLI_LOCAL"] = "true"
 


### PR DESCRIPTION
Fix error:
    sh: 1: bison: not found

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
