### PR TITLE
libtermkey: Depends on glib during build

### DIFF
--- a/Formula/libtermkey.rb
+++ b/Formula/libtermkey.rb
@@ -13,6 +13,7 @@ class Libtermkey < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libtool" => :build
+  depends_on "glib" => :build unless OS.mac?
   depends_on "ncurses" unless OS.mac?
 
   def install


### PR DESCRIPTION
glibc is necessary in order to build `demo-glib` which is part of the default target but never actually deployed during installation.