### PR TITLE
node@4: Reduce Circle CI memory even more

### DIFF
--- a/Formula/node@4.rb
+++ b/Formula/node@4.rb
@@ -40,7 +40,7 @@ class NodeAT4 < Formula
 
   def install
     # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
+    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
 
     args = %W[--prefix=#{prefix} --without-npm]
     args << "--debug" if build.with? "debug"


### PR DESCRIPTION
This is still failing sometimes during the merges.
The numbers of cores is now the same as for the node and
node@6 formula.

