### PR TITLE
jdk 1.8.0-131

### DIFF
--- a/Formula/jdk.rb
+++ b/Formula/jdk.rb
@@ -8,11 +8,11 @@ class Jdk < Formula
   homepage "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
   # tag "linuxbrew"
 
-  version "1.8.0-112"
+  version "1.8.0-131"
   if OS.linux?
-    url "http://download.oracle.com/otn-pub/java/jdk/8u112-b15/jdk-8u112-linux-x64.tar.gz",
+    url "http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz",
       :using => JdkDownloadStrategy
-    sha256 "777bd7d5268408a5a94f5e366c2e43e720c6ce4fe8c59d9a71e2961e50d774a5"
+    sha256 "62b215bdfb48bace523723cdbb2157c665e6a25429c73828a32f00e587301236"
   elsif OS.mac?
     url "http://java.com/"
   end

--- a/Formula/jdk.rb
+++ b/Formula/jdk.rb
@@ -5,6 +5,7 @@ class JdkDownloadStrategy < CurlDownloadStrategy
 end
 
 class Jdk < Formula
+  desc "Java™ Platform, Standard Edition Development Kit (JDK™)."
   homepage "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
   # tag "linuxbrew"
 

--- a/circle.yml
+++ b/circle.yml
@@ -76,7 +76,7 @@ test:
         brew install patchelf
         && brew tap homebrew/science
         && brew tap linuxbrew/xorg
-        && brew test-bot --tap=homebrew/core --keep-old
+        && brew test-bot --tap=homebrew/core
       : timeout: 7200
     - mv *bottle*.json *.tar.gz $CIRCLE_ARTIFACTS/ || true
 notify:


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Update the formula to use **jdk 1.8.0-131** instead of **jdk 1.8.0-112**.

