### PR TITLE
wrk: Depends on makedepend (build) for Linuxbrew

### DIFF
--- a/Formula/wrk.rb
+++ b/Formula/wrk.rb
@@ -14,6 +14,7 @@ class Wrk < Formula
   end
 
   depends_on "openssl"
+  depends_on "makedepend" => :build unless OS.mac?
 
   conflicts_with "wrk-trello", :because => "both install `wrk` binaries"
 


### PR DESCRIPTION
Fix error:
../util/domd: 31: ../util/domd: makedepend: not found

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Closes #3303 