### PR TITLE
compcert: Fix for Linuxbrew

### DIFF
--- a/Formula/compcert.rb
+++ b/Formula/compcert.rb
@@ -31,7 +31,8 @@ class Compcert < Formula
     end
 
     args = ["-prefix", prefix]
-    args << (build.with?("config-x86_64") ? "x86_64-macosx" : "ia32-macosx")
+    os = OS.mac? ? "macosx" : "linux"
+    args << (build.with?("config-x86_64") ? "x86_64-#{os}" : "ia32-#{os}")
     system "./configure", *args
     system "make", "all"
     system "make", "install"


### PR DESCRIPTION
We were trying to configure for macOS

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
