### PR TITLE
sloccount: Depends on flex for Linuxbrew

### DIFF
--- a/Formula/sloccount.rb
+++ b/Formula/sloccount.rb
@@ -13,6 +13,7 @@ class Sloccount < Formula
   end
 
   depends_on "md5sha1sum"
+  depends_on "flex" => :build unless OS.mac?
 
   patch :DATA
 


### PR DESCRIPTION
Note that bison is not needed.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
