### PR TITLE
mas: Depends on macOS

### DIFF
--- a/Formula/mas.rb
+++ b/Formula/mas.rb
@@ -12,6 +12,7 @@ class Mas < Formula
   end
 
   depends_on :xcode => ["8.0", :build]
+  depends_on :macos
 
   def install
     xcodebuild "-project", "mas-cli.xcodeproj",


### PR DESCRIPTION
Who'd have thought that the Mac App Store
was only for macOS?

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
