### PR TITLE
fsevent_watch: Depends on macOS

### DIFF
--- a/Formula/fsevent_watch.rb
+++ b/Formula/fsevent_watch.rb
@@ -15,6 +15,9 @@ class FseventWatch < Formula
     sha256 "fb7163be62f68a7eeea7b67da63d5313dc56c88c28f785f4276308ee14d2bdd1" => :mountain_lion
   end
 
+  # The FSEvents API is macOS-exclusive
+  depends_on :macos
+
   def install
     bin.mkpath
     system "make", "install", "PREFIX=#{prefix}", "CFLAGS=-DCLI_VERSION=\\\"#{version}\\\""


### PR DESCRIPTION
FSEvents is a Mac-only API.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
