### PR TITLE
ical-buddy: Depends on macOS

### DIFF
--- a/Formula/ical-buddy.rb
+++ b/Formula/ical-buddy.rb
@@ -14,6 +14,8 @@ class IcalBuddy < Formula
     sha256 "44b1bb23023bf91a055f77232b0f2cdb2ad64dc389224a480e2236b308abf9a7" => :mavericks
   end
 
+  depends_on :macos
+
   def install
     args = %W[icalBuddy icalBuddy.1 icalBuddyLocalization.1
               icalBuddyConfig.1 COMPILER=#{ENV.cc}]


### PR DESCRIPTION
It is reliant on the macOS calendar database.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

It lacks a test - not like we could test it even if it didn't!
-----
