### PR TITLE
libepoxy: Change libdir for Linuxbrew

### DIFF
--- a/Formula/libepoxy.rb
+++ b/Formula/libepoxy.rb
@@ -21,7 +21,7 @@ class Libepoxy < Formula
     # see https://github.com/anholt/libepoxy/pull/128
     inreplace "src/meson.build", "version=1", "version 1"
     mkdir "build" do
-      system "meson", "--prefix=#{prefix}", ".."
+      system "meson", "--prefix=#{prefix}", *("--libdir=#{lib}" unless OS.mac?), ".."
       system "ninja"
       system "ninja", "test"
       system "ninja", "install"


### PR DESCRIPTION
libepoxy's libdir defaults to lib/"x86_64-linux-gnu",
which makes it hard for pkg-config to find it.

This installs both the pkgconfig directory and the shared
library to lib instead.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This is the new fix for Linuxbrew/brew#442. Note that `gtk+3` compiles on my machine with this version of `libepoxy` without any changes to `brew`.