### PR TITLE
glib: Revision for python

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -3,6 +3,7 @@ class Glib < Formula
   homepage "https://developer.gnome.org/glib/"
   url "https://download.gnome.org/sources/glib/2.52/glib-2.52.3.tar.xz"
   sha256 "25ee7635a7c0fcd4ec91cbc3ae07c7f8f5ce621d8183511f414ded09e7e4e128"
+  revision 1 unless OS.mac?
 
   bottle do
     sha256 "6676ac794f50963131d761521b174c4efee254ed81c87bb232dc0d257c18b9a3" => :sierra


### PR DESCRIPTION
The shebang line in gdbus-codegen references
HOMEBREW_PREFIX/bin/python, which no longer
exists.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

See https://github.com/Linuxbrew/homebrew-core/pull/3412#issuecomment-318874496