### PR TITLE
archey: Depends on macOS

### DIFF
--- a/Formula/archey.rb
+++ b/Formula/archey.rb
@@ -7,6 +7,8 @@ class Archey < Formula
 
   bottle :unneeded
 
+  depends_on :macos
+
   def install
     bin.install "bin/archey"
   end


### PR DESCRIPTION
It's a Mac-specific port of a Linux-centric tool
with the same name which makes assumptions about
what OS it's running on and executes various
programs only available on macOS.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
