### PR TITLE
gnome-doc-utils: revision for python

### DIFF
--- a/Formula/gnome-doc-utils.rb
+++ b/Formula/gnome-doc-utils.rb
@@ -3,6 +3,7 @@ class GnomeDocUtils < Formula
   homepage "https://wiki.gnome.org/Projects/GnomeDocUtils"
   url "https://download.gnome.org/sources/gnome-doc-utils/0.20/gnome-doc-utils-0.20.10.tar.xz"
   sha256 "cb0639ffa9550b6ddf3b62f3b1add92fb92ab4690d351f2353cffe668be8c4a6"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Remove reference to nonexistent python
executable in the xml2po shebang line

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?