### PR TITLE
mercurial: Revision for python

### DIFF
--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -5,6 +5,7 @@ class Mercurial < Formula
   homepage "https://mercurial-scm.org/"
   url "https://mercurial-scm.org/release/mercurial-4.2.2.tar.gz"
   sha256 "b20132dec5ae6d27ee43a133144069895befe09f7e454bfa9e39950a185f0afe"
+  revision 1 unless OS.mac?
 
   bottle do
     sha256 "f43570c72161e66166fa4d97286aed6cfb4e587e8e3406d58ed9886dfbc8b7a3" => :sierra


### PR DESCRIPTION
Remove reference to nonexistent python
executable in shebang lines.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Closes #3455 