### PR TITLE
numpy: Revision for python

### DIFF
--- a/Formula/numpy.rb
+++ b/Formula/numpy.rb
@@ -3,6 +3,7 @@ class Numpy < Formula
   homepage "http://www.numpy.org"
   url "https://files.pythonhosted.org/packages/c0/3a/40967d9f5675fbb097ffec170f59c2ba19fc96373e73ad47c2cae9a30aed/numpy-1.13.1.zip"
   sha256 "c9b0283776085cb2804efff73e9955ca279ba4edafd58d3ead70b61d209c4fbb"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Remove reference to nonexistent python
executable in the f2py shebang line.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?