### PR TITLE
cpio-2.12

### DIFF
--- a/Formula/cpio.rb
+++ b/Formula/cpio.rb
@@ -1,8 +1,8 @@
 class Cpio < Formula
   desc "Copies files into or out of a cpio or tar archive"
   homepage "https://www.gnu.org/software/cpio/"
-  url "https://ftpmirror.gnu.org/cpio/cpio-2.12.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/cpio/cpio-2.12.tar.bz2"
+  url "https://ftp.gnu.org/gnu/cpio/cpio-2.12.tar.bz2"
+  mirror "https://ftpmirror.gnu.org/cpio/cpio-2.12.tar.bz2"
   sha256 "70998c5816ace8407c8b101c9ba1ffd3ebbecba1f5031046893307580ec1296e"
   # tag "linuxbrew"
 

--- a/Formula/cpio.rb
+++ b/Formula/cpio.rb
@@ -1,15 +1,10 @@
 class Cpio < Formula
   desc "Copies files into or out of a cpio or tar archive"
   homepage "https://www.gnu.org/software/cpio/"
-  url "https://ftpmirror.gnu.org/cpio/cpio-2.11.tar.bz2"
-  mirror "https://ftp.gnu.org/gnu/cpio/cpio-2.11.tar.bz2"
-  sha256 "bb820bfd96e74fc6ce43104f06fe733178517e7f5d1cdee553773e8eff7d5bbd"
+  url "https://ftpmirror.gnu.org/cpio/cpio-2.12.tar.bz2"
+  mirror "https://ftp.gnu.org/gnu/cpio/cpio-2.12.tar.bz2"
+  sha256 "70998c5816ace8407c8b101c9ba1ffd3ebbecba1f5031046893307580ec1296e"
   # tag "linuxbrew"
-
-  # Fix the error:
-  # ./stdio.h:358:1: error: 'gets' undeclared here (not in a function)
-  # _GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
-  patch :DATA
 
   def install
     system "./configure",
@@ -24,17 +19,3 @@ class Cpio < Formula
     system "#{bin}/cpio", "--version"
   end
 end
-
-__END__
---- a/gnu/stdio.in.h  2010-03-10 09:27:03.000000000 +0000
-+++ b/gnu/stdio.in.h  2014-11-08 16:56:30.000000000 +0000
-@@ -139,7 +139,9 @@
-    so any use of gets warrants an unconditional warning.  Assume it is
-    always declared, since it is required by C89.  */
- #undef gets
-+#ifdef HAVE_RAW_DECL_GETS
- _GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
-+#endif
- 
- #if @GNULIB_FOPEN@
- # if @REPLACE_FOPEN@

--- a/circle.yml
+++ b/circle.yml
@@ -78,9 +78,9 @@ test:
         brew install patchelf
         && brew tap homebrew/science
         && brew tap linuxbrew/xorg
-        && brew test-bot --tap=homebrew/core --keep-old
+        && brew test-bot --tap=homebrew/core
       : timeout: 7200
     - mv *bottle*.json *.tar.gz $CIRCLE_ARTIFACTS/ || true
 notify:
   webhooks:
-    - url: https://p4142ivuwk.execute-api.us-west-2.amazonaws.com/prod/LinuxbrewTestBot?keep-old=1
+    - url: https://p4142ivuwk.execute-api.us-west-2.amazonaws.com/prod/LinuxbrewTestBot


### PR DESCRIPTION
Update from cpio-2.11 to cpio-2.12
The patch is removed because no more necessary.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
