### PR TITLE
closure-linter: Revision for python

### DIFF
--- a/Formula/closure-linter.rb
+++ b/Formula/closure-linter.rb
@@ -3,6 +3,7 @@ class ClosureLinter < Formula
   homepage "https://developers.google.com/closure/utilities/"
   url "https://github.com/google/closure-linter/archive/v2.3.19.tar.gz"
   sha256 "cd472f560be5af80afccbe94c9d9b534f7c30085510961ad408f8a314ea5c4c2"
+  revision 1 unless OS.mac?
 
   head "https://github.com/google/closure-linter.git"
 


### PR DESCRIPTION
Remove reference to nonexistent python
executable in libexec/bin/gjslint
shebang line.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?