### PR TITLE
jdk7 1.7.0-80

### DIFF
--- a/Formula/jdk7.rb
+++ b/Formula/jdk7.rb
@@ -5,14 +5,15 @@ class JdkDownloadStrategy < CurlDownloadStrategy
 end
 
 class Jdk7 < Formula
+  desc "Java Platform, Standard Edition Development Kit (JDK)."
   homepage "http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html"
   # tag "linuxbrew"
 
-  version "1.7.0.75"
+  version "1.7.0-80"
   if OS.linux?
-    url "http://download.oracle.com/otn-pub/java/jdk/7u75-b13/jdk-7u75-linux-x64.tar.gz",
+    url "http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-7u80-linux-x64.tar.gz",
       :using => JdkDownloadStrategy
-    sha256 "460959219b534dc23e34d77abc306e180b364069b9fc2b2265d964fa2c281610"
+    sha256 "bad9a731639655118740bee119139c1ed019737ec802a630dd7ad7aab4309623"
   elsif OS.mac?
     url "http://java.com/"
   end

--- a/Formula/jdk7.rb
+++ b/Formula/jdk7.rb
@@ -1,9 +1,3 @@
-class JdkDownloadStrategy < CurlDownloadStrategy
-  def _curl_opts
-    super << "--cookie" << "oraclelicense=accept-securebackup-cookie"
-  end
-end
-
 class Jdk7 < Formula
   desc "Java Platform, Standard Edition Development Kit (JDK)."
   homepage "http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html"
@@ -11,8 +5,7 @@ class Jdk7 < Formula
 
   version "1.7.0-80"
   if OS.linux?
-    url "http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-7u80-linux-x64.tar.gz",
-      :using => JdkDownloadStrategy
+    url "http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-7u80-linux-x64.tar.gz"
     sha256 "bad9a731639655118740bee119139c1ed019737ec802a630dd7ad7aab4309623"
   elsif OS.mac?
     url "http://java.com/"

--- a/circle.yml
+++ b/circle.yml
@@ -78,9 +78,9 @@ test:
         brew install patchelf
         && brew tap homebrew/science
         && brew tap linuxbrew/xorg
-        && brew test-bot --tap=homebrew/core --keep-old
+        && brew test-bot --tap=homebrew/core
       : timeout: 7200
     - mv *bottle*.json *.tar.gz $CIRCLE_ARTIFACTS/ || true
 notify:
   webhooks:
-    - url: https://p4142ivuwk.execute-api.us-west-2.amazonaws.com/prod/LinuxbrewTestBot?keep-old=1
+    - url: https://p4142ivuwk.execute-api.us-west-2.amazonaws.com/prod/LinuxbrewTestBot


### PR DESCRIPTION
Update from jdk 1.7.0-75 to jdk 1.7.0-80. Old formula gives 404.
Now an Oracle account is needed to download jdk7. Use a third party
repository.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
