### PR TITLE
Fix media-info dependencies

### DIFF
--- a/Formula/media-info.rb
+++ b/Formula/media-info.rb
@@ -13,6 +13,7 @@ class MediaInfo < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "curl" unless OS.mac?
 
   def install
     cd "ZenLib/Project/GNU/Library" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Depends on libcurl formula on Linux (On mac, Homebrew give a .pc file for the systemwide libcurl library)