### PR TITLE
util-linux: Set bashcompletiondir

### DIFF
--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -27,6 +27,7 @@ class UtilLinux < Formula
       "--disable-ul",
       # Do not install systemd files
       "--without-systemd",
+      "--with-bashcompletiondir=#{bash_completion}"
     ]
     args += %w[--disable-chfn-chsh --disable-login --disable-su --disable-runuser] if build.without? "linux-pam"
     system "./configure", *args

--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -28,7 +28,7 @@ class UtilLinux < Formula
       "--disable-ul",
       # Do not install systemd files
       "--without-systemd",
-      "--with-bashcompletiondir=#{bash_completion}"
+      "--with-bashcompletiondir=#{bash_completion}",
     ]
     args += %w[--disable-chfn-chsh --disable-login --disable-su --disable-runuser] if build.without? "linux-pam"
     system "./configure", *args

--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -3,6 +3,7 @@ class UtilLinux < Formula
   homepage "https://github.com/karelzak/util-linux"
   url "https://www.kernel.org/pub/linux/utils/util-linux/v2.29/util-linux-2.29.tar.xz"
   sha256 "2c59ea67cc7b564104f60532f6e0a95fe17a91acb870ba8fd7e986f273abf9e7"
+  revision 1
   head "https://github.com/karelzak/util-linux.git"
   # tag "linuxbrew"
 
@@ -42,6 +43,9 @@ class UtilLinux < Formula
     conflicts.each do |conflict|
       rm_f Dir.glob("{#{bin},#{man1}}/#{conflict}")
     end
+
+    # conflicts with bash-completion
+    ["mount", "rtcwake"].each { |conflict| rm bash_completion/conflict }
   end
 
   def caveats; <<-EOS.undent

--- a/circle.yml
+++ b/circle.yml
@@ -78,9 +78,9 @@ test:
         brew install patchelf
         && brew tap homebrew/science
         && brew tap linuxbrew/xorg
-        && brew test-bot --tap=homebrew/core --keep-old
+        && brew test-bot --tap=homebrew/core
       : timeout: 7200
     - mv *bottle*.json *.tar.gz $CIRCLE_ARTIFACTS/ || true
 notify:
   webhooks:
-    - url: https://p4142ivuwk.execute-api.us-west-2.amazonaws.com/prod/LinuxbrewTestBot?keep-old=1
+    - url: https://p4142ivuwk.execute-api.us-west-2.amazonaws.com/prod/LinuxbrewTestBot


### PR DESCRIPTION
If bash-completions are installed system-wide,
util-linux will sometimes try to overwrite them,
failing when that requires sudo permissions.

Force bashcompletiondir instead.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>