### PR TITLE
gcc: Remove fails_with :llvm for Linuxbrew

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -60,7 +60,6 @@ class Gcc < Formula
   depends_on "ecj" if build.with?("java") || build.with?("all-languages")
 
   fails_with :gcc_4_0
-  fails_with :llvm
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip


### PR DESCRIPTION
Fix `Error: Calling fails_with :llvm is deprecated!`