### PR TITLE
mongo-c-driver: Depends on openssl for Linuxbrew

### DIFF
--- a/Formula/mongo-c-driver.rb
+++ b/Formula/mongo-c-driver.rb
@@ -16,6 +16,7 @@ class MongoCDriver < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "sphinx-doc" => :build
+  depends_on "openssl" unless OS.mac?
 
   def install
     system "autoreconf", "-fiv"


### PR DESCRIPTION
Fix the errors:
```
/home/linuxbrew/.linuxbrew/Cellar/mongo-cxx-driver/3.1.2/lib/libmongocxx.so:
undefined reference to `mongoc_client_set_ssl_opts'
undefined reference to `mongoc_client_pool_set_ssl_opts'
collect2: error: ld returned 1 exit status
```