### PR TITLE
glibc: Add LinuxKernelRequirement >= 2.6.16

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -22,7 +22,7 @@ end
 class Glibc < Formula
   desc "The GNU C Library"
   homepage "https://www.gnu.org/software/libc/"
-  url "https://ftpmirror.gnu.org/glibc/glibc-2.19.tar.bz2"
+  url "https://ftp.gnu.org/gnu/glibc/glibc-2.19.tar.bz2"
   sha256 "2e293f714187044633264cd9ce0183c70c3aa960a2f77812a6390a3822694d15"
   # tag "linuxbrew"
 

--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -1,3 +1,24 @@
+class LinuxKernelRequirement < Requirement
+  fatal true
+
+  MINIMUM_LINUX_KERNEL_VERSION = "2.6.16".freeze
+
+  def linux_kernel_version
+    @linux_kernel_version ||= Version.new Utils.popen_read("uname -r")
+  end
+
+  satisfy do
+    linux_kernel_version >= MINIMUM_LINUX_KERNEL_VERSION
+  end
+
+  def message
+    <<-EOS.undent
+      Linux kernel version #{MINIMUM_LINUX_KERNEL_VERSION} or greater is required by glibc.
+      Your system has Linux kernel version #{linux_kernel_version}.
+    EOS
+  end
+end
+
 class Glibc < Formula
   desc "The GNU C Library"
   homepage "https://www.gnu.org/software/libc/"
@@ -12,6 +33,8 @@ class Glibc < Formula
   end
 
   option "with-current-kernel", "Compile for compatibility with kernel not older than your current one"
+
+  depends_on LinuxKernelRequirement
 
   # binutils 2.20 or later is required
   depends_on "binutils" => [:build, :recommended]


### PR DESCRIPTION
glibc requires Linux kernel 2.6.16 or greater.