### PR TITLE
glibc: Fix compiling with the brewed gcc for Linuxbrew

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -44,8 +44,6 @@ class Glibc < Formula
   # tag "linuxbrew"
 
   bottle do
-    prefix "/home/linuxbrew/.linuxbrew"
-    cellar "/home/linuxbrew/.linuxbrew/Cellar"
     sha256 "c680445237c7df6c84cb1218d0bf2b76b1d43b92dc165ec6aa537b4c1c064336" => :x86_64_linux
   end
 

--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -7,7 +7,7 @@ class LinuxKernelRequirement < Requirement
     @linux_kernel_version ||= Version.new Utils.popen_read("uname -r")
   end
 
-  satisfy do
+  satisfy(:build_env => false) do
     linux_kernel_version >= MINIMUM_LINUX_KERNEL_VERSION
   end
 

--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -58,11 +58,12 @@ class Glibc < Formula
   # Linux kernel headers 2.6.19 or later are required
   depends_on "linux-headers" => [:build, :recommended]
 
-  env :std
-
   def install
     # Setting RPATH breaks glibc.
-    %w[CPATH LDFLAGS LD_LIBRARY_PATH LD_RUN_PATH LIBRARY_PATH].each { |x| ENV.delete x }
+    %w[
+      LDFLAGS LD_LIBRARY_PATH LD_RUN_PATH LIBRARY_PATH
+      HOMEBREW_DYNAMIC_LINKER HOMEBREW_LIBRARY_PATHS HOMEBREW_RPATH_PATHS
+    ].each { |x| ENV.delete x }
     gcc = Formula["gcc"]
     if gcc.installed? && ENV.compiler == "gcc-" + gcc.version.to_s.split(".")[0]
       # Use the original GCC specs file.

--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -1,3 +1,20 @@
+class GawkRequirement < Requirement
+  fatal true
+
+  satisfy(:build_env => false) do
+    which "gawk"
+  end
+
+  def message
+    <<-EOS.undent
+      gawk is required to build glibc.
+      Install gawk with your host package manager if you have sudo access.
+        sudo apt-get install gawk
+        sudo yum install gawk
+    EOS
+  end
+end
+
 class LinuxKernelRequirement < Requirement
   fatal true
 
@@ -34,6 +51,7 @@ class Glibc < Formula
 
   option "with-current-kernel", "Compile for compatibility with kernel not older than your current one"
 
+  depends_on GawkRequirement
   depends_on LinuxKernelRequirement
 
   # binutils 2.20 or later is required


### PR DESCRIPTION
This PR permits upgrading `glibc`. To test it, add `revision 1` to the `glibc` formula and try `brew upgrade glibc`. I've also fixed installing `glibc` using `--env=super`.