### PR TITLE
vte: Fix test for Linuxbrew

### DIFF
--- a/Formula/vte.rb
+++ b/Formula/vte.rb
@@ -91,11 +91,11 @@ class Vte < Formula
       -lglib-2.0
       -lgobject-2.0
       -lgtk-#{backend}-2.0
-      -lintl
       -lpango-1.0
       -lpangocairo-1.0
       -lvte
     ]
+    flags << "-lintl" if OS.mac?
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end


### PR DESCRIPTION
Only link against -lintl on macOS.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?