### PR TITLE
glibc: Forbid installation if your system glibc is newer

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -1,3 +1,18 @@
+class BrewedGlibcNotOlderRequirement < Requirement
+  fatal true
+
+  satisfy(:build_env => false) do
+    GlibcRequirement.system_version <= Glibc.version
+  end
+
+  def message
+    <<-EOS.undent
+      Your system's glibc version is #{GlibcRequirement.system_version}, and Linuxbrew's gcc version is #{Glibc.version}.
+      Installing a version of glibc that is older than your system's can break formulae installed from source.
+    EOS
+  end
+end
+
 class GawkRequirement < Requirement
   fatal true
 
@@ -36,25 +51,6 @@ class LinuxKernelRequirement < Requirement
   end
 end
 
-class NotOlderGlibcRequirement < Requirement
-  fatal true
-
-  def system_version
-    @system_glibc_version ||= GlibcRequirement.system_version
-  end
-
-  satisfy(:build_env => false) do
-    system_version <= Glibc.version
-  end
-
-  def message
-    <<-EOS.undent
-      Installing an older version of glibc than your system version can break formulae installed from source.
-      Your system has glibc version #{system_version}.
-    EOS
-  end
-end
-
 class Glibc < Formula
   desc "The GNU C Library"
   homepage "https://www.gnu.org/software/libc/"
@@ -68,9 +64,9 @@ class Glibc < Formula
 
   option "with-current-kernel", "Compile for compatibility with kernel not older than your current one"
 
+  depends_on BrewedGlibcNotOlderRequirement
   depends_on GawkRequirement
   depends_on LinuxKernelRequirement
-  depends_on NotOlderGlibcRequirement
 
   # binutils 2.20 or later is required
   depends_on "binutils" => [:build, :recommended]

--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -36,6 +36,25 @@ class LinuxKernelRequirement < Requirement
   end
 end
 
+class NotOlderGlibcRequirement < Requirement
+  fatal true
+
+  def system_version
+    @system_glibc_version ||= GlibcRequirement.system_version
+  end
+
+  satisfy(:build_env => false) do
+    system_version <= Glibc.version
+  end
+
+  def message
+    <<-EOS.undent
+      Installing an older version of glibc than your system version can break formulae installed from source.
+      Your system has glibc version #{system_version}.
+    EOS
+  end
+end
+
 class Glibc < Formula
   desc "The GNU C Library"
   homepage "https://www.gnu.org/software/libc/"
@@ -51,6 +70,7 @@ class Glibc < Formula
 
   depends_on GawkRequirement
   depends_on LinuxKernelRequirement
+  depends_on NotOlderGlibcRequirement
 
   # binutils 2.20 or later is required
   depends_on "binutils" => [:build, :recommended]


### PR DESCRIPTION
Formulae built from source against a newer Glibc
may crash after the installation, as they're looking
for symbols not provided by the older library.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?