### PR TITLE
pkg-config: fix pc-path

### DIFF
--- a/Formula/pkg-config.rb
+++ b/Formula/pkg-config.rb
@@ -16,7 +16,7 @@ class PkgConfig < Formula
     pc_path = %W[
       #{HOMEBREW_PREFIX}/lib/pkgconfig
       #{HOMEBREW_PREFIX}/share/pkgconfig
-    ].join(File::PATH_SEPARATOR)
+    ]
     if OS.mac?
       pc_path += %W[/usr/local/lib/pkgconfig /usr/lib/pkgconfig #{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"]
     else
@@ -27,7 +27,7 @@ class PkgConfig < Formula
                           "--prefix=#{prefix}",
                           "--disable-host-tool",
                           "--with-internal-glib",
-                          "--with-pc-path=#{pc_path}"
+                          "--with-pc-path=#{pc_path.join(File::PATH_SEPARATOR)}"
     system "make"
     system "make", "check"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Joining the array _before_ attempting to add new items to it meant that an exception was raised on macOS, and the final path was added without a seperator before it on Linux.