### PR TITLE
libtool: depend on m4 for Linuxbrew

### DIFF
--- a/Formula/libtool.rb
+++ b/Formula/libtool.rb
@@ -21,6 +21,8 @@ class Libtool < Formula
 
   keg_only :provided_until_xcode43
 
+  depends_on "m4" => :build unless OS.mac?
+
   option "with-default-names", "Do not prepend 'g' to the binary"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Without this, I got an error in `configure` complaining that no compatible m4 was found.