### PR TITLE
subversion: Remove odie from python build

### DIFF
--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -149,7 +149,6 @@ class Subversion < Formula
     if build.with? "python"
       system "make", "swig-py"
       system "make", "install-swig-py"
-      odie
       (lib/"python2.7/site-packages").install_symlink Dir["#{lib}/svn-python/*"]
     end
 


### PR DESCRIPTION
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?