### PR TITLE
webkit2png: Depends on macOS

### DIFF
--- a/Formula/webkit2png.rb
+++ b/Formula/webkit2png.rb
@@ -6,6 +6,9 @@ class Webkit2png < Formula
 
   bottle :unneeded
 
+  # Requires Quartz, as well as other potentially Mac-only libraries
+  depends_on :macos
+
   def install
     bin.install "webkit2png"
   end


### PR DESCRIPTION
Uses Quartz and other possibly Mac-specific libraries.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

Fails at runtime with `Cannot find pyobjc library files.  Are you sure it is installed?`