### PR TITLE
certbot: depend on libffi for Linuxbrew

### DIFF
--- a/Formula/certbot.rb
+++ b/Formula/certbot.rb
@@ -17,6 +17,7 @@ class Certbot < Formula
 
   depends_on "augeas"
   depends_on "dialog"
+  depends_on "libffi" unless OS.mac?
   depends_on "openssl@1.1"
   depends_on :python
 

--- a/Formula/certbot.rb
+++ b/Formula/certbot.rb
@@ -17,9 +17,12 @@ class Certbot < Formula
 
   depends_on "augeas"
   depends_on "dialog"
-  depends_on "libffi" unless OS.mac?
   depends_on "openssl@1.1"
   depends_on :python
+  unless OS.mac?
+    depends_on "libffi"
+    depends_on "pkg-config" => :build
+  end
 
   resource "asn1crypto" do
     url "https://files.pythonhosted.org/packages/67/14/5d66588868c4304f804ebaff9397255f6ec5559e46724c2496e0f26e68d6/asn1crypto-0.22.0.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Without this it failed because it couldn't find `ffi.h`.