### PR TITLE
bigloo: Fix for Linuxbrew

### DIFF
--- a/Formula/bigloo.rb
+++ b/Formula/bigloo.rb
@@ -37,13 +37,13 @@ class Bigloo < Formula
       --mandir=#{man1}
       --infodir=#{info}
       --customgc=yes
-      --os-macosx
       --native=yes
       --disable-alsa
       --disable-mpg123
       --disable-flac
     ]
 
+    args << "--os-macosx" if OS.mac?
     args << "--jvm=yes" if build.with? "jvm"
     args << "--no-gmp" if build.without? "gmp"
 


### PR DESCRIPTION
Fix error:
    export: -Wl,--dynamic-linker: bad variable name

Closes Linuxbrew/homebrew-core#145

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
