### PR TITLE
txr: Depends on bison and flex for Linuxbrew

### DIFF
--- a/Formula/txr.rb
+++ b/Formula/txr.rb
@@ -13,6 +13,11 @@ class Txr < Formula
     sha256 "da1a691c1939f768b066d2bd8d71a06f1ecb6d968e6eeb2231e01d16af646e66" => :mavericks
   end
 
+  unless OS.mac?
+    depends_on "bison" => :build
+    depends_on "flex" => :build
+  end
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
Fix errors:
* Checking for yacc program ... not found
* /bin/bash: flex: command not found

Closes Linuxbrew/homebrew-core#148.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

I'm not sure why I'm not encountering #148 any more - maybe newer compiler, maybe it's a GCC shim, who knows - but I'm marking it as resolving that issue anyhow since no one other than me and Shaun have commented on it since it was created.