### PR TITLE
hub: Fix devel for Linuxbrew

### DIFF
--- a/Formula/hub.rb
+++ b/Formula/hub.rb
@@ -23,6 +23,9 @@ class Hub < Formula
   option "without-docs", "Don't install man pages"
 
   depends_on "go" => :build
+  if !OS.mac? && build.with?("docs") && !build.stable?
+    depends_on :ruby => ["1.9+", :build]
+  end
 
   def install
     if build.stable?


### PR DESCRIPTION
Ruby is needed to generate manpages on the devel release.
Put a Ruby requirement in when building with manpages on
said release, so that a Ruby with development headers is
picked up by RubyRequirement, or else Bundler may fail.

Fix error:
/usr/bin/ruby2.3 -r ./siteconf20170814-32299-1or3huz.rb extconf.rb
mkmf.rb can't find header files for ruby at /usr/lib/ruby/include/ruby.h

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
