### PR TITLE
libosinfo: Depends on libxslt for Linuxbrew

### DIFF
--- a/Formula/libosinfo.rb
+++ b/Formula/libosinfo.rb
@@ -23,6 +23,8 @@ class Libosinfo < Formula
   depends_on "gobject-introspection" => :recommended
   depends_on "vala" => :optional
 
+  depends_on "libxslt" unless OS.mac?
+
   def install
     # avoid wget dependency
     inreplace "Makefile.in", "wget -q -O", "curl -o"


### PR DESCRIPTION
Fix error:
configure: error: Package requirements (libxslt >= 1.0.0) were not met:

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?