### PR TITLE
[Linux] sundials

### DIFF
--- a/Formula/sundials.rb
+++ b/Formula/sundials.rb
@@ -16,7 +16,7 @@ class Sundials < Formula
 
   depends_on "cmake" => :build
   depends_on "suite-sparse"
-  depends_on "veclibfort"
+  depends_on "veclibfort" if OS.mac?
   depends_on :fortran
   depends_on :mpi => [:cc, :f77, :recommended]
 
@@ -44,8 +44,16 @@ class Sundials < Formula
 
   test do
     cp Dir[prefix/"examples/nvector/serial/*"], testpath
-    system ENV.cc, "-I#{include}", "test_nvector.c", "sundials_nvector.c",
-                   "test_nvector_serial.c", "-L#{lib}", "-lsundials_nvecserial"
+    args = %w[
+      -I#{include}
+      test_nvector.c
+      sundials_nvector.c
+      test_nvector_serial.c
+      -L#{lib}
+      -lsundials_nvecserial
+    ]
+    args << "-lm" if OS.linux?
+    system ENV.cc, *args
     assert_match "SUCCESS: NVector module passed all tests",
                  shell_output("./a.out 42 0")
   end


### PR DESCRIPTION
* Don't depend on veclibfort, which is Mac-only
* Link against -lm in the test (needed for testing against glibc)

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?