### PR TITLE
llvm: Do not allow to pour outside of default prefix for Linuxbrew

### DIFF
--- a/Formula/llvm.rb
+++ b/Formula/llvm.rb
@@ -48,7 +48,7 @@ class Llvm < Formula
     end
 
     resource "libcxxabi" do
-      url "http://llvm.org/releases/4.0.1/libcxxabi-4.0.1.src.tar.xz"
+      url "https://llvm.org/releases/4.0.1/libcxxabi-4.0.1.src.tar.xz"
       sha256 "8f08178989a06c66cd19e771ff9d8ca526dd4a23d1382d63e416c04ea9fa1b33"
     end
 
@@ -79,11 +79,17 @@ class Llvm < Formula
   end
 
   bottle do
-    cellar :any if OS.mac?
+    cellar :any
     rebuild 1
     sha256 "109ea0b2b78a44b2256ebb9b2d5966185e7b6a8045cc6dbcea85fab1051ea2a4" => :sierra
     sha256 "f3be215d6e8f41504add8b09ac97d695b988d333266ff163fc2c53405a468a38" => :el_capitan
     sha256 "8ec98b7eaf1de2dca1e2a10caa3edd2cace088185257e7bb39fe068713bf5121" => :yosemite
+  end
+
+  pour_bottle? do
+    default_prefix = BottleSpecification::DEFAULT_PREFIX
+    reason "The bottle needs to be installed into #{default_prefix}."
+    satisfy { OS.mac? || HOMEBREW_PREFIX.to_s == default_prefix }
   end
 
   head do


### PR DESCRIPTION
and use https for the libcxxabi download url.
