### PR TITLE
gtkmm: Fix test for Linuxbrew

### DIFF
--- a/Formula/gtkmm.rb
+++ b/Formula/gtkmm.rb
@@ -101,7 +101,7 @@ class Gtkmm < Formula
       -latkmm-1.6
       -lcairo
       -lcairomm-1.0
-      -lgdk-quartz-2.0
+      -lgdk-#{OS.mac? ? "quartz" : "x11"}-2.0
       -lgdk_pixbuf-2.0
       -lgdkmm-2.4
       -lgio-2.0
@@ -109,14 +109,14 @@ class Gtkmm < Formula
       -lglib-2.0
       -lglibmm-2.4
       -lgobject-2.0
-      -lgtk-quartz-2.0
+      -lgtk-#{OS.mac? ? "quartz" : "x11"}-2.0
       -lgtkmm-2.4
-      -lintl
       -lpango-1.0
       -lpangocairo-1.0
       -lpangomm-1.4
       -lsigc-2.0
     ]
+    flags << "-lintl" if OS.mac?
     system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags
     system "./test"
   end

--- a/Formula/gtkmm.rb
+++ b/Formula/gtkmm.rb
@@ -23,6 +23,8 @@ class Gtkmm < Formula
   needs :cxx11
 
   def install
+    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
+
     ENV.cxx11
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
Only link against -lintl on macOS,
and use the X11 versions of GTK+ and GDK.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?