### PR TITLE
hypre: Restore Linux support [Linux]

### DIFF
--- a/Formula/hypre.rb
+++ b/Formula/hypre.rb
@@ -12,24 +12,54 @@ class Hypre < Formula
     sha256 "e228abcdbeeed01a30b13f1471cb848d309fc306a861d745338b71451374e032" => :yosemite
   end
 
-  depends_on "veclibfort"
+  option "without-accelerate", "Build without Accelerate framework (use internal BLAS routines)"
+
+  depends_on "veclibfort" if build.without?("openblas") && OS.mac?
   depends_on :fortran
   depends_on :mpi => [:cc, :cxx, :f90, :f77]
+  depends_on "openblas" => :recommended unless OS.mac?
 
   def install
     cd "src" do
+      config_args = ["--prefix=#{prefix}"]
+
       ENV["CC"] = ENV["MPICC"]
       ENV["CXX"] = ENV["MPICXX"]
 
-      system "./configure", "--prefix=#{prefix}",
-                            "--with-blas=yes",
-                            "--with-blas-libs=blas cblas",
-                            "--with-blas-lib-dirs=/usr/lib",
-                            "--with-lapack=yes",
-                            "--with-lapack-libs=lapack clapack f77lapack",
-                            "--with-lapack-lib-dirs=/usr/lib",
-                            "--with-MPI",
-                            "--enable-bigint"
+      if build.with? "openblas"
+        config_args += ["--with-blas=yes",
+                        "--with-blas-libs=openblas",
+                        "--with-blas-lib-dirs=#{Formula["openblas"].opt_lib}",
+                        "--with-lapack=yes",
+                        "--with-lapack-libs=openblas",
+                        "--with-lapack-lib-dirs=#{Formula["openblas"].opt_lib}"]
+      elsif build.with? "accelerate"
+        config_args += ["--with-blas=yes",
+                        "--with-blas-libs=blas cblas",
+                        "--with-blas-lib-dirs=/usr/lib",
+                        "--with-lapack=yes",
+                        "--with-lapack-libs=lapack clapack f77lapack",
+                        "--with-lapack-lib-dirs=/usr/lib"]
+      end
+
+      if OS.linux?
+        # on Linux Homebrew formulae will fail to build
+        # shared libraries without the dependent static libraries
+        # compiled with -fPIC
+        ENV.prepend "CFLAGS", "-fPIC"
+        ENV.prepend "CXXFLAGS", "-fPIC"
+        ENV.prepend "FFLAGS", "-fPIC"
+      end
+
+      # MPI library strings for linking depends on compilers
+      # enabled.  Only the C library strings are needed (without the
+      # lib), because hypre is a C library.
+      config_args += ["--with-MPI",
+                      "--with-MPI-include=#{HOMEBREW_PREFIX}/include",
+                      "--with-MPI-lib-dirs=#{HOMEBREW_PREFIX}/lib",
+                      "--with-MPI-libs=mpi"]
+      config_args << "--enable-bigint"
+      system "./configure", *config_args
       system "make", "install"
     end
   end
@@ -42,7 +72,7 @@ class Hypre < Formula
       }
     EOS
 
-    system ENV.cc, "test.cpp", "-o", "test"
+    system ENV.cxx, "test.cpp", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
Restore many of the changes made in homebrew/science:

* Only depend on veclibfort on macOS
* Restore openblas support
* Compile libraries with -fPIC

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>
