### PR TITLE
gtk+3: Build a bottle for Linuxbrew

### DIFF
--- a/Formula/gtk+3.rb
+++ b/Formula/gtk+3.rb
@@ -1,3 +1,4 @@
+# gtk+3: Build a bottle for Linuxbrew
 class Gtkx3 < Formula
   desc "Toolkit for creating graphical user interfaces"
   homepage "https://gtk.org/"


### PR DESCRIPTION
Because #3912 timed out on Travis. Having a bottle for `gtk+3` will hopefully make that less likely in the future.