### PR TITLE
r: Fix for Linuxbrew

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -115,8 +115,10 @@ class R < Formula
     lib.install_symlink Dir[r_home/"lib/*"]
 
     # avoid triggering mandatory rebuilds of r when gcc is upgraded
-    inreplace lib/"R/etc/Makeconf", Formula["gcc"].prefix.realpath,
-                                    Formula["gcc"].opt_prefix
+    inreplace lib/"R/etc/Makeconf",
+      Formula["gcc"].prefix.realpath,
+      Formula["gcc"].opt_prefix,
+      OS.mac?
   end
 
   def post_install


### PR DESCRIPTION
Fix
```
Error: inreplace failed
/home/linuxbrew/.linuxbrew/Cellar/r/3.4.1_2/lib/R/etc/Makeconf:
expected replacement of
<Pathname:/home/linuxbrew/.linuxbrew/Cellar/gcc/5.3.0>
with
<Pathname:/home/linuxbrew/.linuxbrew/opt/gcc>
```