### PR TITLE
dshb: Depends on macOS

### DIFF
--- a/Formula/dshb.rb
+++ b/Formula/dshb.rb
@@ -11,6 +11,7 @@ class Dshb < Formula
   end
 
   depends_on :xcode => ["7.0", :build]
+  depends_on :macos
 
   def install
     system "make", "release"


### PR DESCRIPTION
For various reasons:
* Needs XCode to build
* Needs Swift (not ported yet)
* SystemKit dependency uses Darwin API's

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?