### PR TITLE
vtk: Add undeclared dependencies and build bottle for Linuxbrew

### DIFF
--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -29,8 +29,12 @@ class Vtk < Formula
   depends_on "pyqt" if build.with? "qt"
 
   unless OS.mac?
-    depends_on "tcl-tk"
+    depends_on "expat"
     depends_on "libxml2"
+    depends_on "szip"
+    depends_on "zlib"
+    depends_on "tcl-tk"
+    depends_on :x11
     depends_on "linuxbrew/xorg/mesa"
   end
 


### PR DESCRIPTION
Let's give this a try with circle 2.0; this failed before because of the 2 hours limit, but should be fine now.