### PR TITLE
Remove bottles for boost for Linuxbrew

### DIFF
--- a/Formula/apache-arrow.rb
+++ b/Formula/apache-arrow.rb
@@ -11,7 +11,6 @@ class ApacheArrow < Formula
     sha256 "5fc8f63806fd7937e6d0e7c0f0a729aeca7670ddb2f575df5acda8892f0bb129" => :sierra
     sha256 "7c50efe964a487acbd95156319f7bca07c5c3dfeb7817526d3943695e680d083" => :el_capitan
     sha256 "5302db745369a3b16d8dfe3661270b1b15d710d13eca5ecffe9b1742b5c01e97" => :yosemite
-    sha256 "7021be8431669732613c3643ffe50e3d6ea495df374800aedcd473469ee172f7" => :x86_64_linux
   end
 
   # NOTE: remove ccache with Apache Arrow 0.5 and higher version

--- a/Formula/apngasm.rb
+++ b/Formula/apngasm.rb
@@ -13,7 +13,6 @@ class Apngasm < Formula
     sha256 "073f74cacea8907e430113f4aae80d248887fc1d18de36f64889e683c08e3441" => :el_capitan
     sha256 "5fb1bd67761e2717c78c3842c7effd8835acb5f6193a05516df7cde7ff7051e8" => :yosemite
     sha256 "124cee4bf9746a9e60882cf6fd5b2430265fc661af5dbe9bab2f85e83e985cfa" => :mavericks
-    sha256 "260c029d8193856ca134dd82b1685bfdd4d6ba014422e4c1a71234f69ff233b8" => :x86_64_linux
   end
 
   depends_on "cmake" => :build

--- a/Formula/bastet.rb
+++ b/Formula/bastet.rb
@@ -8,7 +8,6 @@ class Bastet < Formula
     sha256 "debdb55e854497dec7fcf2b8324513ae435ba52df6f963608ec97519368b1587" => :sierra
     sha256 "6480a6a2fcb155c29db0baf135a9cb8d31ef7540866a2f9bb9bfc6d2b50a7690" => :el_capitan
     sha256 "dab9a1b75d5da4c467b37dc49b76a0bbe5c9202eaeb321d60a341ae7cd256098" => :yosemite
-    sha256 "f2b62465a3e3d1a0a943bcf853a9d27e6db53b0a4f227faa5e6f6e90c005b33f" => :x86_64_linux
   end
 
   depends_on "boost"

--- a/Formula/libphonenumber.rb
+++ b/Formula/libphonenumber.rb
@@ -9,7 +9,6 @@ class Libphonenumber < Formula
     sha256 "9a34e37b1341a0127cad367e39097a4377440317cb148ce7a23d5214a43ca22a" => :sierra
     sha256 "4c7dcc63f4213850e43041e4add3f8596dcf099e97b05b85cdcd17dd207a8d1c" => :el_capitan
     sha256 "17d0736ee8895d88658d69986d98406950936f2a657fa2589170732b2c335cb9" => :yosemite
-    sha256 "89f212a51e1ed2a54eaed678aafc088b3728b72a294e8337c0afe339f1a9afe9" => :x86_64_linux
   end
 
   depends_on "cmake" => :build

--- a/Formula/nghttp2.rb
+++ b/Formula/nghttp2.rb
@@ -8,7 +8,6 @@ class Nghttp2 < Formula
     sha256 "b48b0ff3b0bb17e343ff6d2d9cd81fdc399880793e0cab64d04e983067b9d9cf" => :sierra
     sha256 "e5701e7eabba29583b1e067ffd8b942e091c10220efdc991dcb83cd04de45ca4" => :el_capitan
     sha256 "b97d13831724a3436e0f71d89e04352da82ba9ab97238535a56d6062d664590a" => :yosemite
-    sha256 "9dc8ff9563094b5b77ab86a62137cf280616a1324d6d1840d78b3f76d2364cda" => :x86_64_linux
   end
 
   head do

--- a/Formula/pdns.rb
+++ b/Formula/pdns.rb
@@ -8,7 +8,6 @@ class Pdns < Formula
     sha256 "e30011fbb145b6f218f162446110bdc9fc2e97042ee9e3579d1a76042f49c2f2" => :sierra
     sha256 "ed5aa3cc7ad6be4eaf2014e55a2710421f26a810538205a7b66b146e7f36649b" => :el_capitan
     sha256 "f0129da95db9a27333c4c047ecaa0407a60c83a755a71137d54328f564c204b6" => :yosemite
-    sha256 "465a15f807d889d60f1935517c404bd0b1528e8a24ec32f1a7a217a179fcee7b" => :x86_64_linux
   end
 
   head do

--- a/Formula/pdnsrec.rb
+++ b/Formula/pdnsrec.rb
@@ -8,7 +8,6 @@ class Pdnsrec < Formula
     sha256 "cc9312578fb77bed4d92725ccec1a49d40a5113743117aff240d7a7021ca015c" => :sierra
     sha256 "bd074b480630fc4dab01fe3886c2430dc3617aec6e34d6e68cc8cec84ffaebe7" => :el_capitan
     sha256 "efe5c4b834cb36612741b353c4705fda3510f42f8ee09265b4077373e7a05669" => :yosemite
-    sha256 "23c44f0b24643b6f0778e3eb67d77bc30d0eb87e276d7feb980171026e8a0319" => :x86_64_linux
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Due to linkage failures, remove the bottles of
apache-arrow apngasm bastet libphonenumber nghttp2 pdns pdnsrec