### PR TITLE
Revert "phantomjs: update 2.1.1 bottle for Linuxbrew."

### DIFF
--- a/Formula/phantomjs.rb
+++ b/Formula/phantomjs.rb
@@ -28,7 +28,6 @@ class Phantomjs < Formula
     sha256 "370e6f729ac20091c408dc5a1be14361b861bef78f1a52efb201e27e7440cfa4" => :el_capitan
     sha256 "ec65660b5c4097886d52fe0b4928aaefd6d09fb0e6ab707b1fa4d762acf873e1" => :yosemite
     sha256 "d837e04d137ae8ddc8eb807b7ca5a08a0fccdfd513f4fdd4f1d610ce8abc0874" => :mavericks
-    sha256 "4fbfa13c1a51a437549204e56fd94fcec1a28385ebb2ccf163903936775daf96" => :x86_64_linux # glibc 2.19
   end
 
   depends_on MinimumMacOSRequirement => :lion


### PR DESCRIPTION
This reverts commit 0acdba07930f0e9c8b3789b52d355af61da4b4f5.

Fix the error:
```
Missing libraries:
  libicui18n.so.58
  libicuuc.so.58
```

https://travis-ci.org/Linuxbrew/homebrew-core/builds/268442490#L6431

Rebuilding `phantomjs` with `icu4c` failed:
https://github.com/Linuxbrew/homebrew-core/pull/3824