### PR TITLE
fsevents-tools: Depends on macOS

### DIFF
--- a/Formula/fsevents-tools.rb
+++ b/Formula/fsevents-tools.rb
@@ -20,6 +20,9 @@ class FseventsTools < Formula
     depends_on "pkg-config" => :build
   end
 
+  # The FSEvents API is macOS-exclusive
+  depends_on :macos
+
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
FSEvents is a Mac-only API.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?