### PR TITLE
analog: Fix [Linux]

### DIFF
--- a/Formula/analog.rb
+++ b/Formula/analog.rb
@@ -19,13 +19,16 @@ class Analog < Formula
   depends_on "gd"
   depends_on "jpeg"
   depends_on "libpng"
+  depends_on "zlib" unless OS.mac?
 
   def install
+    libs = "-lz"
+    libs += " -lm" unless OS.mac?
     system "make", "CC=#{ENV.cc}",
                    "CFLAGS=#{ENV.cflags}",
                    "DEFS='-DLANGDIR=\"#{pkgshare}/lang/\"' -DHAVE_ZLIB",
-                   "LIBS=-lz",
-                   "OS=OSX"
+                   "LIBS=#{libs}",
+                   "OS=#{OS.mac? ? "OSX" : "UNIX"}"
 
     bin.install "analog"
     pkgshare.install "examples", "how-to", "images", "lang"


### PR DESCRIPTION
* Link against -lm to fix error: undefined reference to `cos'
* Disable other macOS-specific Make rules
* Depend on zlib; it's not strictly necessary but clearly
  was intended to be used.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?