### PR TITLE
argon2: Fix reference to a macOS shared library (libargon2.dylib), re…

### DIFF
--- a/Formula/argon2.rb
+++ b/Formula/argon2.rb
@@ -16,7 +16,7 @@ class Argon2 < Formula
     system "make"
     system "make", "test"
     bin.install "argon2"
-    lib.install "libargon2.dylib", "libargon2.a"
+    lib.install "libargon2.#{OS.mac? ? "dylib" : "so"}", "libargon2.a"
     include.install "include/argon2.h"
     man1.install "man/argon2.1"
     doc.install "argon2-specs.pdf"


### PR DESCRIPTION
…placing it with a Linux one (libargon2.so)

Installation on Linux outputs `Error: No such file or directory - libargon2.dylib` since `libargon2.dylib` is a macOS library, but on Linux it should be instead `libargon2.so`

- [Y] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [Y] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [Y] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [Y] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
