### PR TITLE
afl-fuzz: Fix test for Linuxbrew

### DIFF
--- a/Formula/afl-fuzz.rb
+++ b/Formula/afl-fuzz.rb
@@ -26,7 +26,11 @@ class AflFuzz < Formula
       }
     EOS
 
-    system bin/"afl-clang++", "-g", cpp_file, "-o", "test"
+    if which "clang++"
+      system bin/"afl-clang++", "-g", cpp_file, "-o", "test"
+    else
+      system bin/"afl-g++", "-g", cpp_file, "-o", "test"
+    end
     assert_equal "Hello, world!", shell_output("./test")
   end
 end


### PR DESCRIPTION
Fix the error: Oops, failed to execute 'clang++' - check your PATH