### PR TITLE
docker-credential-helper: depend on mac_os for Linuxbrew

### DIFF
--- a/Formula/docker-credential-helper.rb
+++ b/Formula/docker-credential-helper.rb
@@ -13,6 +13,7 @@ class DockerCredentialHelper < Formula
   end
 
   depends_on "go" => :build
+  depends_on :macos
 
   def install
     ENV["GOPATH"] = buildpath


### PR DESCRIPTION
As the description tells us:
macOS Credential Helper for Docker