### PR TITLE
megatools: Depends on curl for Linuxbrew

### DIFF
--- a/Formula/megatools.rb
+++ b/Formula/megatools.rb
@@ -17,6 +17,8 @@ class Megatools < Formula
   depends_on "glib-networking"
   depends_on "openssl"
 
+  depends_on "curl" unless OS.mac?
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fixes error:

    checking for LIBCURL... no
    configure: error: Package requirements (libcurl) were not met:

    No package 'libcurl' found
