### PR TITLE
bitcoin 0.14.2: depends on bsdmainutils for Linuxbrew

### DIFF
--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -27,6 +27,9 @@ class Bitcoin < Formula
   needs :cxx11
 
   def install
+    # Reduce memory usage below 4 GB for Circle CI.
+    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
+
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -22,6 +22,7 @@ class Bitcoin < Formula
   depends_on "libevent"
   depends_on "miniupnpc"
   depends_on "openssl"
+  depends_on "bsdmainutils" => :build unless OS.mac? # `hexdump` from bsdmainutils required to compile tests
 
   needs :cxx11
 

--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -28,7 +28,7 @@ class Bitcoin < Formula
 
   def install
     # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
+    ENV["MAKEFLAGS"] = "-j8 -l2.5" if ENV["CIRCLECI"]
 
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -28,7 +28,7 @@ class Bitcoin < Formula
 
   def install
     # Reduce memory usage below 4 GB for Circle CI.
-    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
+    ENV["MAKEFLAGS"] = "-j8" if ENV["CIRCLECI"]
 
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
compiling tests depends on `hexdump` from bsdmainutils which is not
provided by GNU Coreutils

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
