### PR TITLE
gcc: Disable multilib for Linuxbrew

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -172,7 +172,8 @@ class Gcc < Formula
         args << "--with-sysroot=#{MacOS.sdk_path}"
       end
 
-      if MacOS.prefer_64_bit?
+      # Fix Linux error: gnu/stubs-32.h: No such file or directory
+      if OS.mac? && MacOS.prefer_64_bit?
         args << "--enable-multilib"
       else
         args << "--disable-multilib"


### PR DESCRIPTION
Fix `error: gnu/stubs-32.h: No such file or directory`

Fixes https://github.com/Linuxbrew/brew/issues/488