### PR TITLE
glibc: Fix BrewedGlibcNotOlderRequirement [Linux]

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -2,7 +2,7 @@ class BrewedGlibcNotOlderRequirement < Requirement
   fatal true
 
   satisfy(:build_env => false) do
-    GlibcRequirement.system_version <= Glibc.version
+    Glibc.version >= GlibcRequirement.system_version
   end
 
   def message


### PR DESCRIPTION
Compare versions rather than strings.

Fix the incorrect error:
```
glibc: Your system's glibc version is 2.5, and Linuxbrew's gcc version is 2.23.
Installing a version of glibc that is older than your system's can break
formulae installed from source.
```