### PR TITLE
isl: Fix the 0.15 bottle

### DIFF
--- a/Formula/isl.rb
+++ b/Formula/isl.rb
@@ -13,10 +13,10 @@ class Isl < Formula
 
   bottle do
     cellar :any
-    sha256 "1430a6e91faca8d8a07dc16cb078ab80707f134f4a3f94853bf007c79d9cd68f" => :high_sierra
-    sha256 "1c2765a5766f8bc022dc49d77d7d32a9c3e92e82452bc63ab534f3c1f18a913c" => :sierra
-    sha256 "00c61068ede0e555b9d41126cfe773f93a1b5f3b4843bc34f001987f940d7796" => :el_capitan
-    sha256 "3f5c77443c140d387297d23056e86e07a9bb3a34328d42edcff7aef47410c1f0" => :yosemite
+    sha256 "8fd8215540c6d44494400fbc964ffabfccfdf806fb4a1de8c8c302f06d998f0f" => :el_capitan
+    sha256 "b370c775e2e670df7cab1375833722c72a1121e49b30d780746878945f7ef9c2" => :yosemite
+    sha256 "13a5858f8a27b63d6613f5f29c44bfc1c9c6b95d625e3fbd1ff71acf17557476" => :mavericks
+    sha256 "4d7ef6be0f083cab40af0debed4f45b1d596728eda4e08605df26fd1e4eb64aa" => :x86_64_linux # glibc 2.19
   end
 
   head do


### PR DESCRIPTION
No need to use `brew pull --bottle`. This PR can be squash merged.