### PR TITLE
gcc 5.4.0

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -221,7 +221,7 @@ class Gcc < Formula
     # Move lib64/* to lib/ on Linuxbrew
     lib64 = Pathname.new "#{lib}64"
     if lib64.directory?
-      system "mv #{lib64}/* #{lib}/" # Do not use FileUtils.mv with Ruby 1.9.3
+      mv Dir[lib64/"*"], lib
       rmdir lib64
       prefix.install_symlink "lib" => "lib64"
     end

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -146,7 +146,7 @@ class Gcc < Formula
     ]
 
     # Fix cc1: error while loading shared libraries: libisl.so.15
-    args << "--with-boot-ldflags=-static-libstdc++ -static-libgcc #{ENV["LDFLAGS"]}" if OS.linux?
+    args << "--with-boot-ldflags=-static-libstdc++ -static-libgcc #{ENV["LDFLAGS"]}" unless OS.mac?
 
     # The pre-Mavericks toolchain requires the older DWARF-2 debugging data
     # format to avoid failure during the stage 3 comparison of object files.
@@ -188,7 +188,7 @@ class Gcc < Formula
         bin.install_symlink bin/"gfortran-#{version_suffix}" => "gfortran"
       end
 
-      if OS.linux?
+      unless OS.mac?
         # Create cpp, gcc and g++ symlinks
         bin.install_symlink "cpp-#{version_suffix}" => "cpp"
         bin.install_symlink "gcc-#{version_suffix}" => "gcc"
@@ -235,7 +235,7 @@ class Gcc < Formula
   end
 
   def post_install
-    if OS.linux?
+    unless OS.mac?
       # Create cc and c++ symlinks, unless they already exist
       homebrew_bin = Pathname.new "#{HOMEBREW_PREFIX}/bin"
       homebrew_bin.install_symlink "gcc" => "cc" unless (homebrew_bin/"cc").exist?

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -134,7 +134,7 @@ class Gcc < Formula
       "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
       "--with-mpc=#{Formula["libmpc"].opt_prefix}",
       "--with-isl=#{Formula["isl"].opt_prefix}",
-      "--with-system-zlib",
+      ("--with-system-zlib" if OS.mac?),
       "--enable-stage1-checking",
       "--enable-checking=release",
       "--enable-lto",

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -226,6 +226,14 @@ class Gcc < Formula
       rmdir lib64
       prefix.install_symlink "lib" => "lib64"
     end
+
+    # Strip the binaries to reduce their size.
+    unless OS.mac?
+      system("strip", "--strip-unneeded", "--preserve-dates", *Dir[prefix/"**/*"].select do |f|
+        f = Pathname.new(f)
+        f.file? && (f.elf? || f.extname == ".a")
+      end)
+    end
   end
 
   def add_suffix(file, suffix)

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -22,9 +22,9 @@ class Gcc < Formula
       mirror "https://ftpmirror.gnu.org/gcc/gcc-7.2.0/gcc-7.2.0.tar.xz"
       sha256 "1cf7adf8ff4b5aa49041c8734bbcf1ad18cc4c94d0029aae0f4e48841088479a"
     else
-      url "http://ftpmirror.gnu.org/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2"
-      mirror "https://ftp.gnu.org/gnu/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2"
-      sha256 "b84f5592e9218b73dbae612b5253035a7b34a9a1f7688d2e1bfaaf7267d5c4db"
+      url "https://ftp.gnu.org/gnu/gcc/gcc-5.4.0/gcc-5.4.0.tar.bz2"
+      mirror "http://ftpmirror.gnu.org/gcc/gcc-5.4.0/gcc-5.4.0.tar.bz2"
+      sha256 "608df76dec2d34de6558249d8af4cbee21eceddbcb580d666f7a5a583ca3303a"
     end
   end
 
@@ -34,7 +34,6 @@ class Gcc < Formula
     sha256 "bc96bddd0e9f7c074eab7c4036973bc60d5d5ef4489e65db64018363d63d248d" => :sierra
     sha256 "755ed27d3aa9b60523aead68f36d17f6396b9f4b622a0972c05eae3302922d5c" => :el_capitan
     sha256 "eecedf7c9233bd1553d3e22027f415f15a9d1a7ad11e486855bf3a8f7d36ed23" => :yosemite
-    sha256 "2c6ae8e098830e19f87d8426b49d353b6cbc0b89d9259bae242d57b6694c9039" => :x86_64_linux # glibc 2.19
   end
 
   # GCC's Go compiler is not currently supported on macOS.

--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -29,7 +29,7 @@ class Gcc < Formula
   end
 
   bottle do
-    cellar :any if OS.linux?
+    cellar :any
     sha256 "3b7606d2b98cf9ca5c25d2620d2c9d6c146a910f6063c071ac4bf5abdeb73faa" => :high_sierra
     sha256 "bc96bddd0e9f7c074eab7c4036973bc60d5d5ef4489e65db64018363d63d248d" => :sierra
     sha256 "755ed27d3aa9b60523aead68f36d17f6396b9f4b622a0972c05eae3302922d5c" => :el_capitan
@@ -64,8 +64,9 @@ class Gcc < Formula
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   pour_bottle? do
-    reason "The bottle needs the Xcode CLT to be installed."
-    satisfy { MacOS::CLT.installed? }
+    default_prefix = BottleSpecification::DEFAULT_PREFIX
+    reason "The bottle needs the Xcode CLT to be installed and to be installed into #{default_prefix}."
+    satisfy { !OS.mac? || (MacOS::CLT.installed? && HOMEBREW_PREFIX.to_s == default_prefix) }
   end
 
   def version_suffix


### PR DESCRIPTION
+ Strip the executables to reduce their size.
+ Use cellar :any
+ Change if OS.linux? to unless OS.mac?
+ Fix style

```
Stable: Please use https://
'fails_with :llvm' is now a no-op so should be removed
Don't need 'FileUtils.' before mv.
Use the `mv` Ruby method instead of `system "mv `
```