### PR TITLE
gmp: Add --build=core2-linux-gnu

### DIFF
--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -15,7 +15,7 @@ class Gmp < Formula
     sha256 "ff7e7d5c74ac58c6f15369eb2d351603e1e5a49daec135b216a0355c6de3c680" => :x86_64_linux
   end
 
-  depends_on "m4" unless OS.mac?
+  depends_on "m4" => :build unless OS.mac?
 
   option :cxx11
 

--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -19,14 +19,17 @@ class Gmp < Formula
 
   option :cxx11
 
+  env :super if OS.linux?
+
   def install
     ENV.cxx11 if build.cxx11?
     args = %W[--prefix=#{prefix} --enable-cxx]
 
     if OS.mac?
       args << "--build=core2-apple-darwin#{`uname -r`.to_i}" if build.bottle?
-    elsif Hardware::CPU.intel? && Hardware::CPU.is_32_bit?
-      args << "ABI=32"
+    else
+      args << "--build=core2-linux-gnu" if build.bottle?
+      args << "ABI=32" if Hardware::CPU.intel? && Hardware::CPU.is_32_bit?
     end
 
     system "./configure", *args


### PR DESCRIPTION
Add `--build=core2-linux-gnu` when building a bottle for Linuxbrew. Otherwise GMP uses the popcnt instruction, which is not available on all supported CPUs.

Fixes https://github.com/Linuxbrew/homebrew-core/issues/1683