### PR TITLE
gmp: Revert to 6.1.1

### DIFF
--- a/Formula/gmp.rb
+++ b/Formula/gmp.rb
@@ -1,34 +1,29 @@
 class Gmp < Formula
   desc "GNU multiple precision arithmetic library"
   homepage "https://gmplib.org/"
-  url "https://gmplib.org/download/gmp/gmp-6.1.2.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz"
-  sha256 "87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912"
+  url "https://gmplib.org/download/gmp/gmp-6.1.1.tar.xz"
+  mirror "https://ftp.gnu.org/gnu/gmp/gmp-6.1.1.tar.xz"
+  sha256 "d36e9c05df488ad630fff17edb50051d6432357f9ce04e34a09b3d818825e831"
 
   bottle do
     cellar :any
     rebuild 1
-    sha256 "e245ef776fba2762e245a0182b9c9c74cab2135dc7a29c3bd0811a223e7220ee" => :high_sierra
     sha256 "cd4a916966007092af477a76655cc1f66546d00bf5e581a5dfef334f8436aeb0" => :sierra
     sha256 "01b24de832db7aa24ee14159feb5a16e0e3e18932e6f38d221331bb45feb6a1a" => :el_capitan
     sha256 "3752709f0bab1999fa9d5407bcd3135a873b48fc34d5e6ea123fd68c4cf3644d" => :yosemite
-    sha256 "ff7e7d5c74ac58c6f15369eb2d351603e1e5a49daec135b216a0355c6de3c680" => :x86_64_linux
+    sha256 "a9b92c1ac7cc79df39c5bf7f3c2b0abeb26b9bc417c13d55e3628058aaaa301c" => :x86_64_linux # glibc 2.19
   end
-
-  depends_on "m4" unless OS.mac?
 
   option :cxx11
 
   def install
     ENV.cxx11 if build.cxx11?
     args = %W[--prefix=#{prefix} --enable-cxx]
-
     if OS.mac?
       args << "--build=core2-apple-darwin#{`uname -r`.to_i}" if build.bottle?
-    elsif Hardware::CPU.intel? && Hardware::CPU.is_32_bit?
-      args << "ABI=32"
+    else
+      args << "ABI=32" if Hardware::CPU.intel? && Hardware::CPU.is_32_bit?
     end
-
     system "./configure", *args
     system "make"
     system "make", "check"


### PR DESCRIPTION
The gmp 6.1.2 bottle includes advanced CPU instructions, such as popcnt.
Fix: `gcc: internal compiler error: Illegal instruction`
This PR can be merged without updating the bottle.