### PR TITLE
Add cmd/strip

### DIFF
--- a/cmd/brew-strip.rb
+++ b/cmd/brew-strip.rb
@@ -1,0 +1,15 @@
+#:  * `strip` [`--all`]
+#:    Strip binary executables and libraries to reduce their size.
+#:
+#:    If `--all` is passed, strip all installed formulae.
+
+require File.expand_path("../strip", __FILE__)
+
+odie "Command not found: strip" unless which "strip"
+formulae = if ARGV.include?("--all") || ARGV.include?("--installed")
+  Formula.installed
+else
+  raise FormulaUnspecifiedError if ARGV.named.empty?
+  ARGV.resolved_formulae
+end.sort
+formulae.each { |f| Homebrew.strip_formula f }

--- a/cmd/strip.rb
+++ b/cmd/strip.rb
@@ -1,0 +1,43 @@
+module Homebrew
+  module_function
+
+  # Return true if the file is a binary executable or library.
+  def binary_object?(file)
+    f = Pathname.new file
+    return false unless f.file?
+    return true if f.extname == ".a"
+    if OS.mac?
+      f.dylib? || f.mach_o_executable? || f.mach_o_bundle?
+    else
+      f.elf?
+    end
+  end
+
+  # Strip a keg.
+  def strip(keg)
+    keg = Keg.new keg unless keg.is_a? Keg
+    binaries = Dir[keg/"**/*"].select do |f|
+      !File.symlink?(f) && binary_object?(f)
+    end
+    return if binaries.empty?
+
+    puts "  #{keg} (#{keg.abv})"
+    not_writable = binaries.reject { |f| File.writable? f }
+    begin
+      safe_system "chmod", "u+w", *not_writable unless not_writable.empty?
+      args = ["--strip-unneeded", "--preserve-dates"] unless OS.mac?
+      system "strip", *args, *binaries, err: (:close unless ARGV.verbose?)
+    ensure
+      system "chmod", "u-w", *not_writable unless not_writable.empty?
+    end
+    puts "  #{keg} (#{keg.abv})"
+  end
+
+  # Strip all the installed kegs of a formula.
+  def strip_formula(formula)
+    kegs = formula.installed_kegs
+    return ofail "Formula not installed: #{formula.full_name}" if kegs.empty?
+    ohai "Stripping #{formula.full_name}..."
+    kegs.each { |keg| keg.lock { strip keg } }
+  end
+end


### PR DESCRIPTION
Strip binary executables and libraries to reduce their size.

# Command line usage

```
==> Stripping gcc...
  /home/sjackman/.linuxbrew/Cellar/gcc/5.3.0 (1,353 files, 252.9MB)
  /home/sjackman/.linuxbrew/Cellar/gcc/5.3.0 (1,353 files, 203.7MB)
```

# Usage in a formula

```ruby
require File.expand_path("../../cmd/strip", __FILE__)
Homebrew.strip prefix
```