### PR TITLE
intltool: Bump revision for Linuxbrew

### DIFF
--- a/Formula/intltool.rb
+++ b/Formula/intltool.rb
@@ -3,6 +3,7 @@ class Intltool < Formula
   homepage "https://wiki.freedesktop.org/www/Software/intltool"
   url "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz"
   sha256 "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any_skip_relocation
@@ -12,7 +13,6 @@ class Intltool < Formula
     sha256 "da6c24f1cc40fdf6ae286ec003ecd779d0f866fe850e36f5e5953786fa45a561" => :yosemite
     sha256 "5deeef3625d52f71d633e7510396d0028ec7b7ccf40c78b5d254bdf4214e6363" => :mavericks
     sha256 "739e17a9f4e75913118a8ef0fd2a7ad7d645769cc61aeb1d6bcf760fe4bd48a7" => :mountain_lion
-    sha256 "2b0bc62fa22240902e2bc04b91d6f25b0989e224953ed99ad66d06ad9b37b34d" => :x86_64_linux # glibc 2.19
   end
 
   unless OS.mac?


### PR DESCRIPTION
We did not bump the revision, but since the bottle was intially built,
the code was changed and XML::Parser was vendored.
Building new bottles will allow to distribute XML::Parser,
that can then be used by the other formulae relying on intltool.