### PR TITLE
transmission.rb: fix - add curl dependency.

### DIFF
--- a/Formula/transmission.rb
+++ b/Formula/transmission.rb
@@ -16,6 +16,7 @@ class Transmission < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libevent"
+  depends_on "curl" => :build unless OS.mac?
 
   if build.with? "nls"
     depends_on "intltool" => :build


### PR DESCRIPTION
See https://github.com/Linuxbrew/homebrew-core/issues/4539

`brew audit --strict transmission` returns "incorrect file permissions", but those permissions are the same as every other formula (?)

```
brew audit --strict transmission
transmission:
  * Incorrect file permissions (664): chmod 644 /home/devrana/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/transmission.rb
Error: 1 problem in 1 formula
```
