### PR TITLE
transmission.rb: fix - add curl dependency (#2)

### DIFF
--- a/Formula/transmission.rb
+++ b/Formula/transmission.rb
@@ -16,6 +16,7 @@ class Transmission < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libevent"
+  depends_on "curl" unless OS.mac?
 
   if build.with? "nls"
     depends_on "intltool" => :build


### PR DESCRIPTION
See: https://github.com/Linuxbrew/homebrew-core/issues/4539.

And: https://github.com/Linuxbrew/homebrew-core/pull/4552