### PR TITLE
python3: really hide tcl-tk's info message

### DIFF
--- a/Formula/python3.rb
+++ b/Formula/python3.rb
@@ -383,7 +383,7 @@ class Python3 < Formula
       For more information see: https://www.python.org/download/mac/tcltk/
     EOS
 
-    text += tk_caveats unless MacOS.version >= :lion && OS.mac?
+    text += tk_caveats if OS.mac? && !MacOS.version >= :lion
     text
   end
 


### PR DESCRIPTION
Follow up from #4777, where I used the wrong logic.