### PR TITLE
redshift: fix disable mac-specific configs on linux platform

### DIFF
--- a/Formula/redshift.rb
+++ b/Formula/redshift.rb
@@ -26,14 +26,17 @@ class Redshift < Formula
   depends_on "glib"
 
   def install
+    # Needed by intltool (xml::parser)
+    ENV.prepend_path "PERL5LIB", "#{Formula["intltool"].libexec}/lib/perl5" unless OS.mac?
+
     args = %W[
       --prefix=#{prefix}
-      --enable-corelocation
+      --#{OS.mac? ? "enable" : "disable"}-corelocation
       --disable-silent-rules
       --disable-dependency-tracking
       --disable-geoclue
       --disable-geoclue2
-      --enable-quartz
+      --#{OS.mac? ? "enable" : "disable"}-quartz
       --with-systemduserunitdir=no
       --disable-gui
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
