### PR TITLE
mitmproxy: fix depends_on "libffi" unless OS.mac?

### DIFF
--- a/Formula/mitmproxy.rb
+++ b/Formula/mitmproxy.rb
@@ -19,6 +19,11 @@ class Mitmproxy < Formula
   depends_on "openssl@1.1"
   depends_on :python3
   depends_on "protobuf"
+  unless OS.mac?
+    depends_on "libffi"
+    # pkg-config helps setuptools find libffi
+    depends_on "pkg-config" => :build
+  end
 
   resource "EditorConfig" do
     url "https://files.pythonhosted.org/packages/3b/c9/ea1eb869568f3dca689eb8528f9bead16f3544a38447d86dedbcd45b4e8f/EditorConfig-0.12.1.tar.gz"
@@ -196,6 +201,9 @@ class Mitmproxy < Formula
   end
 
   def install
+    # Reduce memory usage below 4 GB for Circle CI.
+    ENV["MAKEFLAGS"] = "-j4 -l2.5" if ENV["CIRCLECI"]
+
     venv = virtualenv_create(libexec, "python3")
     venv.pip_install resources
     venv.pip_install_and_link buildpath


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
