### PR TITLE
gdb: fix add --without-python parameter on linux platform as needed

### DIFF
--- a/Formula/gdb.rb
+++ b/Formula/gdb.rb
@@ -47,6 +47,8 @@ class Gdb < Formula
       args << "--with-python=#{HOMEBREW_PREFIX}"
     elsif OS.mac?
       args << "--with-python=/usr"
+    else
+      args << "--without-python"
     end
 
     if build.with? "version-suffix"


### PR DESCRIPTION
add --without-python parameter on linux platform as needed