### PR TITLE
fontforge: Fix for Linuxbrew

### DIFF
--- a/Formula/fontforge.rb
+++ b/Formula/fontforge.rb
@@ -65,7 +65,7 @@ class Fontforge < Formula
 
     # The app here is not functional.
     # If you want GUI/App support, check the caveats to see how to get it.
-    (pkgshare/"osx/FontForge.app").rmtree
+    (pkgshare/"osx/FontForge.app").rmtree if OS.mac?
 
     if build.with? "extra-tools"
       cd "contrib/fonttools" do
@@ -84,7 +84,7 @@ class Fontforge < Formula
     Alternatively, install with Homebrew-Cask:
       brew cask install fontforge
     EOS
-  end
+  end if OS.mac?
 
   test do
     system bin/"fontforge", "-version"


### PR DESCRIPTION
Fix
```
Error: No such file or directory @ unlink_internal -
/home/linuxbrew/.linuxbrew/Cellar/fontforge/20170731_2/share/fontforge/osx/FontForge.app
```