### PR TITLE
igraph: add dependencies on libxml2 and openblas

### DIFF
--- a/Formula/igraph.rb
+++ b/Formula/igraph.rb
@@ -15,6 +15,10 @@ class Igraph < Formula
 
   depends_on "glpk"
   depends_on "gmp"
+  unless OS.mac?
+    depends_on "libxml2"
+    depends_on "openblas"
+  end
 
   def install
     system "./configure", "--disable-debug",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

I got the following errors by `brew audit --strict` but I think they should be ignored:
```
igraph:
  * C: 18: col 31: Don't use OS.mac?; Homebrew/core only supports macOS
  * C: 19: col 32: Don't use OS.mac?; Homebrew/core only supports macOS
Error: 2 problems in 1 formula
```
-----

This is a fix for #4992. The patch originally comes from Homebrew/homebrew-science#6038, but in this commit I just added 2 lines for the dependencies.