### PR TITLE
tor-browser 7.0.10 (new formula)

### DIFF
--- a/Formula/tor-browser.rb
+++ b/Formula/tor-browser.rb
@@ -1,0 +1,18 @@
+class TorBrowser < Formula
+  desc "Modified Firefox with privacy add-ons, encryption & advanced proxy"
+  homepage "https://www.torproject.org/projects/torbrowser.html.en"
+  url "https://www.torproject.org/dist/torbrowser/7.0.10/tor-browser-linux64-7.0.10_en-US.tar.xz"
+  version "7.0.10"
+  sha256 "10eebffe22594d336441ed59e5edc97ba1d296eb7d94bca3ff94ebfac2da3e34"
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink libexec/"start-tor-browser.desktop" => "tor-browser"
+  end
+
+  test do
+    cd(libexec) do
+      assert_equal "Launching './Browser/start-tor-browser --detach --verbose --version'...\nMozilla Firefox 52.5.0\n", shell_output("#{bin}/tor-browser --verbose --version 2>&1")
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

decided against naming `torbrowser` like [it's cask counterpart](https://github.com/caskroom/homebrew-cask/blob/3eb87ae0bd34a976f003075875de6deaee2ce086/Casks/torbrowser.rb) because that one didn't show up in `brew search` for `tor` or `browser` (this naming does for both)
so i figured this'd be more discoverable