### PR TITLE
numpy: fix issue #5033 by customizing a 'site.cfg' file to tell the installer where to find OpenBLAS

### DIFF
--- a/Formula/numpy.rb
+++ b/Formula/numpy.rb
@@ -32,6 +32,13 @@ class Numpy < Formula
   end
 
   def install
+    config = <<~EOS
+      [DEFAULT]
+      library_dirs = #{HOMEBREW_PREFIX}/lib
+      include_dirs = #{HOMEBREW_PREFIX}/include
+    EOS
+    Pathname("site.cfg").write config
+
     Language::Python.each_python(build) do |python, version|
       dest_path = lib/"python#{version}/site-packages"
       dest_path.mkpath


### PR DESCRIPTION
…d BLAS/ATLAS/OpenBLAS to fix issue #5033

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
