### PR TITLE
Update of graphviz on source url

### DIFF
--- a/Formula/graphviz.rb
+++ b/Formula/graphviz.rb
@@ -1,7 +1,7 @@
 class Graphviz < Formula
   desc "Graph visualization software from AT&T and Bell Labs"
   homepage "https://graphviz.org/"
-  url "https://graphviz.org/pub/graphviz/stable/SOURCES/graphviz-2.40.1.tar.gz"
+  url "https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz"
   sha256 "ca5218fade0204d59947126c38439f432853543b0818d9d728c589dfe7f3a421"
   version_scheme 1
 


### PR DESCRIPTION
`https://graphviz.org/pub/graphviz/stable/SOURCES/graphviz-2.40.1.tar.gz` is no longer available.

and, `https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz` is the new url.

