### PR TITLE
glibc: Prevent a cyclic dependency on gawk

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -91,10 +91,15 @@ class Glibc < Formula
       LDFLAGS LD_LIBRARY_PATH LD_RUN_PATH LIBRARY_PATH
       HOMEBREW_DYNAMIC_LINKER HOMEBREW_LIBRARY_PATHS HOMEBREW_RPATH_PATHS
     ].each { |x| ENV.delete x }
-    gcc = Formula["gcc"]
-    if gcc.installed? && ENV.compiler == "gcc-" + gcc.version.to_s.split(".")[0]
+
+    gcc_keg = begin
+      Keg.for HOMEBREW_PREFIX/"bin"/ENV.cc
+    rescue NotAKegError
+      nil
+    end
+    if gcc_keg
       # Use the original GCC specs file.
-      specs = gcc.lib/"gcc/x86_64-unknown-linux-gnu/#{gcc.version}/specs.orig"
+      specs = gcc_keg.lib/"gcc/x86_64-unknown-linux-gnu/#{gcc_keg.version}/specs.orig"
       raise "The original GCC specs file is missing: #{specs}" unless specs.readable?
       ENV["LDFLAGS"] = "-specs=#{specs}"
 

--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -17,7 +17,8 @@ class GawkRequirement < Requirement
   fatal true
 
   satisfy(:build_env => false) do
-    which "gawk"
+    # Returning which("gawk") causes a cyclic dependency.
+    !which("gawk").nil?
   end
 
   def message


### PR DESCRIPTION
Returning `which("gawk")` causes `glibc` to depend on `gawk` and creates a
cylic dependency, because the `gawk` bottle depends `glibc`.

Use `Keg.for` to find the gcc specs file. The previous system was fragile and didn't work if the installed version of `gcc` is different than the current version in the formula.

No need to update the bottle. Rebase and merge.
