### PR TITLE
ghc@8.0: Use dynamic_elf? [Linux]

### DIFF
--- a/Formula/ghc@8.0.rb
+++ b/Formula/ghc@8.0.rb
@@ -144,7 +144,7 @@ class GhcAT80 < Formula
         Dir["ghc/stage2/build/tmp/ghc-stage2", "libraries/*/dist-install/build/*.so",
             "rts/dist/build/*.so*", "utils/*/dist*/build/tmp/*"].each do |s|
           file = Pathname.new(s)
-          keg.change_rpath(file, Keg::PREFIX_PLACEHOLDER, HOMEBREW_PREFIX.to_s) if file.mach_o_executable? || file.dylib?
+          keg.change_rpath(file, Keg::PREFIX_PLACEHOLDER, HOMEBREW_PREFIX.to_s) if file.dynamic_elf?
         end
       end
 


### PR DESCRIPTION
Use dynamic_elf? rather than mach_o_executable? and dylib?.

No need to update the bottle. Squash and merge please.