### PR TITLE
glibc: Print the locales being installed [Linux]

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -149,8 +149,10 @@ class Glibc < Formula
     # Compile locale definition files
     mkdir_p lib/"locale"
     locales = ENV.map { |k, v| v if k[/^LANG$|^LC_/] && v != "C" }.compact
-    locales << "en_US.UTF-8" # Required by gawk make check
-    locales.uniq.each do |locale|
+    # en_US.UTF-8 is required by gawk make check
+    locales = (locales + ["en_US.UTF-8"]).sort.uniq
+    ohai "Installing locale data for #{locales.join(" ")}"
+    locales.each do |locale|
       lang, charmap = locale.split(".", 2)
       if !charmap.nil?
         system bin/"localedef", "-i", lang, "-f", charmap, locale


### PR DESCRIPTION
No need to update the bottle. Squash and merge.

Missing locale data causes warnings like this one:
```
perl -e 'import ENV'
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LANG = "en_CA.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
```

The workaround is
```sh
HOMEBREW_NO_ENV_FILTERING=1 brew postinstall glibc
```