### PR TITLE
libidn2: Build dependency on gettext [Linux]

### DIFF
--- a/Formula/libidn2.rb
+++ b/Formula/libidn2.rb
@@ -22,7 +22,11 @@ class Libidn2 < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "gettext"
+  if OS.mac?
+    depends_on "gettext"
+  else
+    depends_on "gettext" => :build
+  end
   depends_on "libunistring"
 
   def install


### PR DESCRIPTION
libidn2 has no linkage to gettext.

Fixes https://github.com/Linuxbrew/homebrew-core/issues/5431