### PR TITLE
 kyoto-tycoon fix

### DIFF
--- a/Formula/kyoto-tycoon.rb
+++ b/Formula/kyoto-tycoon.rb
@@ -14,7 +14,7 @@ class KyotoTycoon < Formula
   depends_on "lua" => :recommended
   depends_on "kyoto-cabinet"
 
-  patch :DATA if MacOS.version >= :mavericks
+  patch :DATA if MacOS.version >= :mavericks || !OS.mac?
 
   def install
     # Locate kyoto-cabinet for non-/usr/local builds


### PR DESCRIPTION
Hello,

I am trying to install kyoto-tycoon in a fresh linuxbrew environment and the compilation fails (see https://gist.github.com/3d0f4a086343b2296804a7fce7724e92 )
I have found that if I remove the condition at https://github.com/Linuxbrew/homebrew-core/blob/master/Formula/kyoto-tycoon.rb#L17 to make brew apply the patch on my system (RHEL7) it works

Regards,
Matthieu