### PR TITLE
sratoolkit: Single make process and better script for finding HDF5

### DIFF
--- a/Formula/sratoolkit.rb
+++ b/Formula/sratoolkit.rb
@@ -28,6 +28,11 @@ class Sratoolkit < Formula
   end
 
   def install
+    # sratoolkit seems to have race conditions during the build and exhibit
+    # during pacbio util builds
+    # Issue: https://github.com/Linuxbrew/homebrew-core/issues/5323
+    ENV.deparallelize unless OS.mac?
+
     ngs_sdk_prefix = buildpath/"ngs-sdk-prefix"
     resource("ngs-sdk").stage do
       cd "ngs-sdk" do
@@ -53,6 +58,10 @@ class Sratoolkit < Formula
     # Fix the error: ld: library not found for -lmagic-static
     # Upstream PR: https://github.com/ncbi/sra-tools/pull/105
     inreplace "tools/copycat/Makefile", "-smagic-static", "-smagic"
+
+    # Fix the error: undefined reference to `SZ_encoder_enabled'
+    # Issue: https://github.com/Linuxbrew/homebrew-core/issues/5323
+    inreplace "tools/pacbio-load/Makefile", "-shdf5 ", "-shdf5 -ssz " unless OS.mac?
 
     system "./configure",
       "--prefix=#{prefix}",


### PR DESCRIPTION
Posting here as Homebrew/homebrew-core#22888 was deemed out of scope for upstream homebrew.

sratoolkit no longer compiled on Linuxbrew. See Linuxbrew/homebrew-core#5323 for more details.

This is linked to the code not finding the hdf5 library, meaning pacbio applications did not compile, and a parallel make process going wrong. I have turned off the parallel make and introduced a new konfigure.perl as a remote resource. This is not an inline patch because another resource must also be patched.

I've asked if the maintainers will be releasing a new version but they have not answered if they will.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
