### PR TITLE
glibc: Fix error when locating the gcc keg [Linux]

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -94,7 +94,7 @@ class Glibc < Formula
 
     gcc_keg = begin
       Keg.for HOMEBREW_PREFIX/"bin"/ENV.cc
-    rescue NotAKegError
+    rescue Errno::ENOENT, NotAKegError
       nil
     end
     if gcc_keg


### PR DESCRIPTION
Fix
```
Error: No such file or directory @ realpath_rec - /home/guest/my_graphviz/bin/gcc-4.8
```