### PR TITLE
Gnuplot: fix issue where make install was trying to create /usr/local/share/texmf for latex files

### DIFF
--- a/Formula/gnuplot.rb
+++ b/Formula/gnuplot.rb
@@ -3,13 +3,12 @@ class Gnuplot < Formula
   homepage "http://www.gnuplot.info/"
   url "https://downloads.sourceforge.net/project/gnuplot/gnuplot/5.2.2/gnuplot-5.2.2.tar.gz"
   sha256 "a416d22f02bdf3873ef82c5eb7f8e94146795811ef808e12b035ada88ef7b1a1"
-  revision 1
+  revision OS.mac? ? 1 : 2
 
   bottle do
     sha256 "1523a40b075f76d80ac32274a4b896ba5d11075e5cd0601fbdb8c524f9f8d8cb" => :high_sierra
     sha256 "bd4e2e49fec4afa21df5c5d9c976818eb8928376a2d482c493c6d2098c034e16" => :sierra
     sha256 "2c2689aee797c5539bfee0fefef7e11cdbe3c8c063ca4057a8a2261087d380cf" => :el_capitan
-    sha256 "f6559e297b86c864e671947927478e6a64055d895e2f6fa469e90f32c9387ba3" => :x86_64_linux
   end
 
   head do
@@ -90,7 +89,7 @@ class Gnuplot < Formula
     args << "--without-lua" if build.without? "lua"
     args << (build.with?("aquaterm") ? "--with-aquaterm" : "--without-aquaterm")
     args << (build.with?("x11") ? "--with-x" : "--without-x")
-    args << "--with-texdir=#{prefix}/share/texmf"
+    args << "--with-texdir=#{share}/texmf" unless OS.mac?
 
     system "./prepare" if build.head?
     system "./configure", *args

--- a/Formula/gnuplot.rb
+++ b/Formula/gnuplot.rb
@@ -90,6 +90,7 @@ class Gnuplot < Formula
     args << "--without-lua" if build.without? "lua"
     args << (build.with?("aquaterm") ? "--with-aquaterm" : "--without-aquaterm")
     args << (build.with?("x11") ? "--with-x" : "--without-x")
+    args << "--with-texdir=#{prefix}/share/texmf"
 
     system "./prepare" if build.head?
     system "./configure", *args


### PR DESCRIPTION
I was trying to:
```
brew install gnuplot --with-aquaterm --with-cairo --with-qt --with-wxmac --with-x11
```
where the build attempted to create /usr/local/share/texmf to install gnuplot's 
latex files during make install stage. These files should be installed into
the cellar directory.