### PR TITLE
ghc: fix 'Array to String' type error

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -147,8 +147,8 @@ class Ghc < Formula
       # Change the dynamic linker and RPATH of the binary executables.
       if OS.linux? && Formula["glibc"].installed?
         keg = Keg.new(prefix)
-        ["ghc/stage2/build/tmp/ghc-stage2", Dir["libraries/*/dist-install/build/*.so",
-            "rts/dist/build/*.so*", "utils/*/dist*/build/tmp/*"]].each do |s|
+        ["ghc/stage2/build/tmp/ghc-stage2"].concat(Dir["libraries/*/dist-install/build/*.so",
+            "rts/dist/build/*.so*", "utils/*/dist*/build/tmp/*"]).each do |s|
           file = Pathname.new(s)
           keg.change_rpath(file, Keg::PREFIX_PLACEHOLDER, HOMEBREW_PREFIX.to_s) if file.dynamic_elf?
         end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
This fixes #5397 's 'Array to String' problem using the adjustments suggested by @kaboroevich. 

**However, it should be noted that this still doesn't allow a successful GHC build on my system, as I now encounter #4413.** This prevents checking the latter two items on the checklist. It should also be noted that neither I nor @kaboroevich by our own descriptions have much Ruby experience, so I'd appreciate a quick sanity check for this narrow issue.

With respect to #4413, is it better for me to open a new issue as I (slowly) explore it, or should I wait until I have something actionable I can take to GHC upstream? For now, I'm putting things in a gist [here](https://gist.github.com/ebzheng/c91bdae5a05d6d1b5655fcc70d36e778).