### PR TITLE
cryptopp: fix building for linuxbrew

### DIFF
--- a/Formula/cryptopp.rb
+++ b/Formula/cryptopp.rb
@@ -7,6 +7,13 @@ class Cryptopp < Formula
   # https://cryptopp.com/wiki/Config.h#Options_and_Defines
   bottle :disable, "Library and clients must be built on the same microarchitecture"
 
+  # fix for linuxbrew. to be removed in the next release.
+  # https://github.com/weidai11/cryptopp/pull/575
+  patch do
+    url "https://github.com/weidai11/cryptopp/commit/0bec01233352c2675cf0436dd35c9c6f5a2206ac.patch?full_index=1"
+    sha256 "af18461f9d0e59c5fed86475a5cf93e91b06fe79818ba27ca6e4b23265cd609d"
+  end unless OS.mac?
+
   def install
     system "make", "shared", "all", "CXX=#{ENV.cxx}"
     system "./cryptest.exe", "v"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Applying upstream patch https://github.com/weidai11/cryptopp/pull/575