### PR TITLE
ocaml: set the xorg dependency as optional

### DIFF
--- a/Formula/ocaml.rb
+++ b/Formula/ocaml.rb
@@ -39,7 +39,7 @@ class Ocaml < Formula
   option "with-flambda", "Install with flambda support"
 
   depends_on :x11 => :optional
-  depends_on "linuxbrew/xorg/xorg" unless OS.mac?
+  depends_on "linuxbrew/xorg/xorg" if build.with?("x11") && !OS.mac?
 
   def install
     ENV.deparallelize # Builds are not parallel-safe, esp. with many cores


### PR DESCRIPTION
Fix issue mentionned in https://github.com/Linuxbrew/homebrew-core/pull/5857