### PR TITLE
wimlib: Depend on libxml2

### DIFF
--- a/Formula/wimlib.rb
+++ b/Formula/wimlib.rb
@@ -15,7 +15,7 @@ class Wimlib < Formula
   depends_on "pkg-config" => :build
   depends_on "ntfs-3g" => :optional
   depends_on "openssl"
-  depends_on "libxml2"
+  depends_on "libxml2" unless OS.mac?
 
   def install
     # fuse requires librt, unavailable on OSX

--- a/Formula/wimlib.rb
+++ b/Formula/wimlib.rb
@@ -36,7 +36,7 @@ class Wimlib < Formula
   test do
     # make a directory containing a dummy 1M file
     mkdir("foo")
-    system "dd", "if=/dev/random", "of=foo/bar", "bs=1M", "count=1"
+    system "dd", "if=/dev/random", "of=foo/bar", (OS.mac? ? "bs=1m" : "bs=1M"), "count=1"
 
     # capture an image
     ENV.append "WIMLIB_IMAGEX_USE_UTF8", "1"

--- a/Formula/wimlib.rb
+++ b/Formula/wimlib.rb
@@ -36,7 +36,7 @@ class Wimlib < Formula
   test do
     # make a directory containing a dummy 1M file
     mkdir("foo")
-    system "dd", "if=/dev/random", "of=foo/bar", "bs=1m", "count=1"
+    system "dd", "if=/dev/random", "of=foo/bar", "bs=1M", "count=1"
 
     # capture an image
     ENV.append "WIMLIB_IMAGEX_USE_UTF8", "1"

--- a/Formula/wimlib.rb
+++ b/Formula/wimlib.rb
@@ -15,6 +15,7 @@ class Wimlib < Formula
   depends_on "pkg-config" => :build
   depends_on "ntfs-3g" => :optional
   depends_on "openssl"
+  depends_on "libxml2"
 
   def install
     # fuse requires librt, unavailable on OSX


### PR DESCRIPTION
I could not get wimlib to compile on my machine (configure failing) without
installing libxml2 first prior to installing wimlib itself. Thus wimlib now
`depends_on "libxml2"`

Perhaps this should be further symboled with `:build`, should it?