### PR TITLE
fix gdbm on linux by adding _GNU_SOURCE

### DIFF
--- a/Formula/gdbm.rb
+++ b/Formula/gdbm.rb
@@ -31,6 +31,7 @@ class Gdbm < Formula
     ]
 
     args << "--enable-libgdbm-compat" if build.with? "libgdbm-compat"
+    args << "CFLAGS=-D_GNU_SOURCE" if OS.linux?
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
macro `_GNU_SOURCE` is need on some linux platforms.
see [https://patchwork.ozlabs.org/patch/771300/](https://patchwork.ozlabs.org/patch/771300/)