### PR TITLE
abyss: Fix test [Linux]

### DIFF
--- a/Formula/abyss.rb
+++ b/Formula/abyss.rb
@@ -44,7 +44,12 @@ class Abyss < Formula
 
   test do
     testpath.install resource("testdata")
-    system "#{bin}/abyss-pe", "k=25", "name=ts", "in=reads1.fastq reads2.fastq"
+    if OS.mac? || which("column")
+      system "#{bin}/abyss-pe", "k=25", "name=ts", "in=reads1.fastq reads2.fastq"
+    else
+      # Fix error: abyss-tabtomd: column: not found
+      system "#{bin}/abyss-pe", "unitigs", "scaffolds", "k=25", "name=ts", "in=reads1.fastq reads2.fastq"
+    end
     system "#{bin}/abyss-fac", "ts-unitigs.fa"
   end
 end


### PR DESCRIPTION
Fix
```
error: abyss-tabtomd: column: not found
```
No new bottle is required. Squash and merge.