### PR TITLE
e2fsprogs - enable shared libs too

### DIFF
--- a/Formula/automake.rb
+++ b/Formula/automake.rb
@@ -10,6 +10,7 @@ class Automake < Formula
     sha256 "8135f20535b5b225c082106b005d85aa280010b1c1eeedb56d456b6e3478359a" => :high_sierra
     sha256 "8135f20535b5b225c082106b005d85aa280010b1c1eeedb56d456b6e3478359a" => :sierra
     sha256 "8accb0115d48ed86969fb4591bd911dded858fba5346f76715e9cd7233ce21ba" => :el_capitan
+    sha256 "452c4e47b09bfa3709a6e0fccd91200fe5cec19685fad4fccca77288446161ba" => :x86_64_linux
   end
 
   keg_only :provided_until_xcode43

--- a/Formula/e2fsprogs.rb
+++ b/Formula/e2fsprogs.rb
@@ -1,16 +1,15 @@
 class E2fsprogs < Formula
   desc "Utilities for the ext2, ext3, and ext4 file systems"
-  homepage "https://e2fsprogs.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/e2fsprogs/e2fsprogs/v1.43.9/e2fsprogs-1.43.9.tar.gz"
-  sha256 "5be0ffc01b9720a3f3ccfc86396016baf1334b98751fefa09e0c63eaffdc3897"
-
+  homepage "https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/about/"
+  url "https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/snapshot/e2fsprogs-1.43.9.tar.gz"
+  sha256 "89b9b19045aeae76888ec5d2cdd9fa74a5b5d18721382a2403df87b295d53633"
+  revision 1 unless OS.mac?
   head "https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git"
 
   bottle do
     sha256 "d3d586958ff43cf2bbb58bfa47773585c1023931020001b942211fa57b51b3fc" => :high_sierra
     sha256 "57fcc0cb4cff5a0a29a0226615ca397ae56f1df46796d43f2b9155a56dbdfd96" => :sierra
     sha256 "cbfd5ec222f8d56ffdc13f9e42c85893a1e9b7621ec8e4b9f07bb9be7843812a" => :el_capitan
-    sha256 "89dd34baaaf60cf1cc32e21df909a3eeb744e8374d5e1bbaac110591451dfb5c" => :x86_64_linux
   end
 
   keg_only "this installs several executables which shadow macOS system commands"
@@ -19,7 +18,10 @@ class E2fsprogs < Formula
   depends_on "gettext"
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--disable-e2initrd-helper"
+    system "./configure",
+           "--prefix=#{prefix}",
+           "--disable-e2initrd-helper",
+           *("--enable-elf-shlibs" unless OS.mac?)
     system "make"
     system "make", "install"
     system "make", "install-libs"


### PR DESCRIPTION
This patch just adds `--enable-elf-shlibs` to the command line so that `.so` libs are built as well as `.a` static ones.  The `libcom_err.so` is needed for `table2asn_GFF` being built for `brewsci/bio`.


- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
