### PR TITLE
automake 1.16 - replace Perl 'none'

### DIFF
--- a/Formula/automake.rb
+++ b/Formula/automake.rb
@@ -4,14 +4,18 @@ class Automake < Formula
   url "https://ftp.gnu.org/gnu/automake/automake-1.16.tar.xz"
   mirror "https://ftpmirror.gnu.org/automake/automake-1.16.tar.xz"
   sha256 "f98f2d97b11851cbe7c2d4b4eaef498ae9d17a3c2ef1401609b7b4ca66655b8a"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any_skip_relocation
     sha256 "8135f20535b5b225c082106b005d85aa280010b1c1eeedb56d456b6e3478359a" => :high_sierra
     sha256 "8135f20535b5b225c082106b005d85aa280010b1c1eeedb56d456b6e3478359a" => :sierra
     sha256 "8accb0115d48ed86969fb4591bd911dded858fba5346f76715e9cd7233ce21ba" => :el_capitan
-    sha256 "452c4e47b09bfa3709a6e0fccd91200fe5cec19685fad4fccca77288446161ba" => :x86_64_linux
   end
+
+  # Linux bug fix: https://github.com/Linuxbrew/homebrew-core/issues/6275
+  # Function 'none' was only introduced in List::Util 1.33, so we emulate it
+  patch :DATA unless OS.mac?
 
   keg_only :provided_until_xcode43
 
@@ -54,3 +58,18 @@ class Automake < Formula
     system "./test"
   end
 end
+
+__END__
+diff -bur automake-1.16/bin/automake.in  automake-1.16.new/bin/automake.in
+--- automake-1.16/bin/automake.in       2018-02-26 01:13:58.000000000 +1100
++++ automake-1.16.new/bin/automake.in   2018-03-04 10:28:25.357886554 +1100
+@@ -73,7 +73,8 @@
+ use Automake::Language;
+ use File::Basename;
+ use File::Spec;
+-use List::Util 'none';
++use List::Util 'reduce';
++sub none (&@) { my $code=shift; reduce { $a && !$code->(local $_ = $b) } 1, @_; }
+ use Carp;
+
+ ## ----------------------- ##


### PR DESCRIPTION
*Resolves https://github.com/Linuxbrew/homebrew-core/issues/6275*

- [ ] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
