### PR TITLE
Switch thefuck to Python 3

### DIFF
--- a/Formula/thefuck.rb
+++ b/Formula/thefuck.rb
@@ -15,7 +15,7 @@ class Thefuck < Formula
     sha256 "749035abba81d339478eeec0823eed85c3ed89c88231c55d801b51a17f4fd1f8" => :el_capitan
   end
 
-  depends_on "python"
+  depends_on "python3"
 
   resource "colorama" do
     url "https://files.pythonhosted.org/packages/e6/76/257b53926889e2835355d74fec73d82662100135293e17d382e2b74d1669/colorama-0.3.9.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
Thefuck will remove it's Python 3 support soon so we have to switch. The current formula fails since it has missing dependencies for Python 2.