### PR TITLE
isl: Revert isl to 0.18 for Linuxbrew

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -13,7 +13,7 @@ class Gcc < Formula
 
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org/"
-  revision OS.mac? ? 1 : 2
+  revision 1
 
   head "svn://gcc.gnu.org/svn/gcc/trunk"
 
@@ -30,9 +30,11 @@ class Gcc < Formula
   end
 
   bottle do
+    cellar :any
     sha256 "e28abdcd4b1eca7b8bdfc76779e8d6343eb11d8fc4e9c523f03c3c1c887aac2a" => :high_sierra
     sha256 "eef4c6b68313e913b3c71329575699e960a384044b12a76fd880a500fb8dbf1c" => :sierra
     sha256 "a2a77d7caeda7cb6dcacebc2f5113f7a8a3579a146b3a9b539f060409198bba1" => :el_capitan
+    sha256 "4c2282e0e6fea90ab2dc1540ad7f95319f8f41c0254f6dc7ae2d112c616c55d8" => :x86_64_linux
   end
 
   # GCC's Go compiler is not currently supported on macOS.

--- a/Formula/isl.rb
+++ b/Formula/isl.rb
@@ -7,16 +7,22 @@ class Isl < Formula
   # and update isl_version() function accordingly.  All other names will
   # result in isl_version() function returning "UNKNOWN" and hence break
   # package detection.
-  url "http://isl.gforge.inria.fr/isl-0.19.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/isl/isl_0.19.orig.tar.xz"
-  sha256 "6d6c1aa00e2a6dfc509fa46d9a9dbe93af0c451e196a670577a148feecf6b8a5"
+  if OS.mac?
+    url "http://isl.gforge.inria.fr/isl-0.19.tar.xz"
+    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/isl/isl_0.19.orig.tar.xz"
+    sha256 "6d6c1aa00e2a6dfc509fa46d9a9dbe93af0c451e196a670577a148feecf6b8a5"
+  else
+    url "http://isl.gforge.inria.fr/isl-0.18.tar.xz"
+    mirror "https://mirrors.ocf.berkeley.edu/debian/pool/main/i/isl/isl_0.18.orig.tar.xz"
+    sha256 "0f35051cc030b87c673ac1f187de40e386a1482a0cfdf2c552dd6031b307ddc4"
+  end
 
   bottle do
     cellar :any
     sha256 "e286024c142af0e968d8562e83745a05dd059dbe226c41fe6053c8fd481815fe" => :high_sierra
     sha256 "23c7305a7f227e1749a15584eb203ec9f1f49f1f4312753a9ee360f89b71d304" => :sierra
     sha256 "c00c85da652a572356e54cad1a6ff986f136f6088c142dfcdbfc166bd7144d1e" => :el_capitan
-    sha256 "f8d4d7837ab4ff809e3950d3ea5bf973b6ad7b5b54381059b17695124cf388e0" => :x86_64_linux
+    sha256 "964e01eb84ffc9082464b5232d8965f8b6d92dc691d8525d0b6daca88154c4ca" => :x86_64_linux
   end
 
   head do


### PR DESCRIPTION
isl 0.19 is missing the file include/isl/band.h, which is required for building GCC 5.5.0.

gcc: Revert gcc to revision 1 for Linuxbrew

Use the previous gcc bottle, which was built using isl 0.18.