### PR TITLE
gcc 7.3.0 (new formula)

### DIFF
--- a/Aliases/gcc@7
+++ b/Aliases/gcc@7
@@ -1,1 +1,0 @@
-../Formula/gcc.rb

--- a/Formula/gcc@7.rb
+++ b/Formula/gcc@7.rb
@@ -1,0 +1,178 @@
+class GccAT7 < Formula
+  desc "GNU compiler collection"
+  homepage "https://gcc.gnu.org/"
+  revision 1
+  head "svn://gcc.gnu.org/svn/gcc/trunk"
+
+  stable do
+    url "https://ftp.gnu.org/gnu/gcc/gcc-7.3.0/gcc-7.3.0.tar.xz"
+    mirror "https://ftpmirror.gnu.org/gcc/gcc-7.3.0/gcc-7.3.0.tar.xz"
+    sha256 "832ca6ae04636adbb430e865a1451adf6979ab44ca1c8374f61fba65645ce15c"
+  end
+
+  bottle do
+    sha256 "e28abdcd4b1eca7b8bdfc76779e8d6343eb11d8fc4e9c523f03c3c1c887aac2a" => :high_sierra
+    sha256 "eef4c6b68313e913b3c71329575699e960a384044b12a76fd880a500fb8dbf1c" => :sierra
+    sha256 "a2a77d7caeda7cb6dcacebc2f5113f7a8a3579a146b3a9b539f060409198bba1" => :el_capitan
+  end
+
+  option "with-jit", "Build just-in-time compiler"
+  option "with-nls", "Build with native language support (localization)"
+
+  depends_on "gmp"
+  depends_on "libmpc"
+  depends_on "mpfr"
+  depends_on "isl"
+
+  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
+  cxxstdlib_check :skip
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  pour_bottle? do
+    reason "The bottle needs the Xcode CLT to be installed."
+    satisfy { MacOS::CLT.installed? }
+  end
+
+  def version_suffix
+    if build.head?
+      "HEAD"
+    else
+      version.to_s.slice(/\d/)
+    end
+  end
+
+  # Fix for libgccjit.so linkage on Darwin
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64089
+  # https://github.com/Homebrew/homebrew-core/issues/1872#issuecomment-225625332
+  # https://github.com/Homebrew/homebrew-core/issues/1872#issuecomment-225626490
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/e9e0ee09389a54cc4c8fe1c24ebca3cd765ed0ba/gcc/6.1.0-jit.patch"
+    sha256 "863957f90a934ee8f89707980473769cff47ca0663c3906992da6afb242fb220"
+  end
+
+  # Fix parallel build on APFS filesystem
+  # Remove for 7.4.0 and later
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81797
+  if MacOS.version >= :high_sierra
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/df0465c02a/gcc/apfs.patch"
+      sha256 "f7772a6ba73f44a6b378e4fe3548e0284f48ae2d02c701df1be93780c1607074"
+    end
+  end
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    # We avoiding building:
+    #  - Ada, which requires a pre-existing GCC Ada compiler to bootstrap
+    #  - Go, currently not supported on macOS
+    #  - BRIG
+    languages = %w[c c++ objc obj-c++ fortran]
+
+    # JIT compiler is off by default, enabling it has performance cost
+    languages << "jit" if build.with? "jit"
+
+    osmajor = `uname -r`.chomp
+
+    args = [
+      "--build=x86_64-apple-darwin#{osmajor}",
+      "--prefix=#{prefix}",
+      "--libdir=#{lib}/gcc/#{version_suffix}",
+      "--enable-languages=#{languages.join(",")}",
+      # Make most executables versioned to avoid conflicts.
+      "--program-suffix=-#{version_suffix}",
+      "--with-gmp=#{Formula["gmp"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc"].opt_prefix}",
+      "--with-isl=#{Formula["isl"].opt_prefix}",
+      "--with-system-zlib",
+      "--enable-checking=release",
+      "--with-pkgversion=Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip,
+      "--with-bugurl=https://github.com/Homebrew/homebrew-core/issues",
+    ]
+
+    args << "--disable-nls" if build.without? "nls"
+    args << "--enable-host-shared" if build.with?("jit")
+
+    # Ensure correct install names when linking against libgcc_s;
+    # see discussion in https://github.com/Homebrew/homebrew/pull/34303
+    inreplace "libgcc/config/t-slibgcc-darwin", "@shlib_slibdir@", "#{HOMEBREW_PREFIX}/lib/gcc/#{version_suffix}"
+
+    mkdir "build" do
+      unless MacOS::CLT.installed?
+        # For Xcode-only systems, we need to tell the sysroot path.
+        # "native-system-headers" will be appended
+        args << "--with-native-system-header-dir=/usr/include"
+        args << "--with-sysroot=#{MacOS.sdk_path}"
+      end
+
+      system "../configure", *args
+
+      make_args = []
+      # Use -headerpad_max_install_names in the build,
+      # otherwise lto1 load commands cannot be edited on El Capitan
+      if MacOS.version == :el_capitan
+        make_args << "BOOT_LDFLAGS=-Wl,-headerpad_max_install_names"
+      end
+
+      system "make", *make_args
+      system "make", "install"
+
+      bin.install_symlink bin/"gfortran-#{version_suffix}" => "gfortran"
+    end
+
+    # Handle conflicts between GCC formulae and avoid interfering
+    # with system compilers.
+    # Rename man7.
+    Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
+    # Even when we disable building info pages some are still installed.
+    info.rmtree
+  end
+
+  def add_suffix(file, suffix)
+    dir = File.dirname(file)
+    ext = File.extname(file)
+    base = File.basename(file, ext)
+    File.rename file, "#{dir}/#{base}-#{suffix}#{ext}"
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<~EOS
+      #include <stdio.h>
+      int main()
+      {
+        puts("Hello, world!");
+        return 0;
+      }
+    EOS
+    system "#{bin}/gcc-#{version_suffix}", "-o", "hello-c", "hello-c.c"
+    assert_equal "Hello, world!\n", `./hello-c`
+
+    (testpath/"hello-cc.cc").write <<~EOS
+      #include <iostream>
+      int main()
+      {
+        std::cout << "Hello, world!" << std::endl;
+        return 0;
+      }
+    EOS
+    system "#{bin}/g++-#{version_suffix}", "-o", "hello-cc", "hello-cc.cc"
+    assert_equal "Hello, world!\n", `./hello-cc`
+
+    (testpath/"test.f90").write <<~EOS
+      integer,parameter::m=10000
+      real::a(m), b(m)
+      real::fact=0.5
+
+      do concurrent (i=1:m)
+        a(i) = a(i) + fact*b(i)
+      end do
+      write(*,"(A)") "Done"
+      end
+    EOS
+    system "#{bin}/gfortran", "-o", "test", "test.f90"
+    assert_equal "Done\n", `./test`
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This adds gcc 7.x support to the Linuxbrew. 

Further, I think some changes made in this formula can be backported to the gcc-5 and gcc-6 formulae. 

Compared with the existing gcc formula, some of the major changes are:

 * Pass the specs to ./configure so that gcc can pickup brewed glibc.
   This fixes the building failure if the building system uses brewed gcc and brewed glibc
 * Use the `--libdir` flag to tell gcc to install libraries under versioned path.
   This is essential to allow different version of gcc formulae to be linked into
   the HOMEBREW_PREFIX.
   However, such flag should be only passed for the `gcc@*` versioned formulae.
   For the main formula `gcc`, we want its libraries to be linked to the
   unversioned path. So the bottles can be poured regardless the version of gcc.
 * Revamp the spec file. Specifically, use `-isysroot /nonexistent` and `-idirafter <dir>`
   to instruct gcc to search its internal header files before the system ones.
