### PR TITLE
cairo: allow to build without xorg [Linux]

### DIFF
--- a/Formula/cairo.rb
+++ b/Formula/cairo.rb
@@ -23,7 +23,7 @@ class Cairo < Formula
   keg_only :provided_pre_mountain_lion
 
   depends_on "pkg-config" => :build
-  depends_on :x11 => :optional
+  depends_on :x11 => :optional if OS.mac?
   depends_on "freetype"
   depends_on "fontconfig"
   depends_on "libpng"
@@ -31,7 +31,7 @@ class Cairo < Formula
   depends_on "glib"
   unless OS.mac?
     depends_on "zlib"
-    depends_on "linuxbrew/xorg/xorg"
+    depends_on "linuxbrew/xorg/xorg" => :recommended
   end
 
   def install
@@ -46,7 +46,7 @@ class Cairo < Formula
       --enable-quartz-image
     ] if OS.mac?
 
-    if build.with?("x11") || !OS.mac?
+    if build.with?("x11") || build.with?("xorg")
       args << "--enable-xcb=yes" << "--enable-xlib=yes" << "--enable-xlib-xrender=yes"
     else
       args << "--enable-xcb=no" << "--enable-xlib=no" << "--enable-xlib-xrender=no"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

This solves the issue for users running Linuxbrew in headless server and
no X11 environment.
