### PR TITLE
Substitute Lua's prefix only on Mac OS

### DIFF
--- a/Formula/lua@5.1.rb
+++ b/Formula/lua@5.1.rb
@@ -53,7 +53,7 @@ class LuaAT51 < Formula
   def install
     # Use our CC/CFLAGS to compile.
     inreplace "src/Makefile" do |s|
-      s.gsub! "@LUA_PREFIX@", prefix
+      s.gsub! "@LUA_PREFIX@", prefix if OS.mac?
       s.remove_make_var! "CC"
       s.change_make_var! "CFLAGS", "#{ENV.cflags} $(MYCFLAGS)"
       s.change_make_var! "MYLDFLAGS", ENV.ldflags


### PR DESCRIPTION
Fix #6861 build.