### PR TITLE
swig: depends on ruby for test [Linux]

### DIFF
--- a/Formula/swig.rb
+++ b/Formula/swig.rb
@@ -12,6 +12,7 @@ class Swig < Formula
   end
 
   depends_on "pcre"
+  depends_on "ruby" => :test
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/swig.rb
+++ b/Formula/swig.rb
@@ -12,7 +12,7 @@ class Swig < Formula
   end
 
   depends_on "pcre"
-  depends_on "ruby" => :test
+  depends_on "ruby" => :test unless OS.mac?
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

```
/home/linuxbrew/.linuxbrew/bin/ld: cannot find -lruby-static
```