### PR TITLE
r: Enable build without X11

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -23,7 +23,7 @@ class R < Formula
   depends_on :java => :optional
 
   unless OS.mac?
-    depends_on "cairo"
+    depends_on "cairo" => :recommended
     depends_on "curl"
     depends_on "tcl-tk" => :optional
     depends_on "linuxbrew/xorg/xorg" => :recommended
@@ -57,8 +57,8 @@ class R < Formula
 
     if OS.linux?
       args << "--libdir=#{lib}" # avoid using lib64 on CentOS
-      args << "--with-cairo"
-      args << "--with-x" if build.with?("x11")
+      args << "--with-cairo" if build.with? "cairo"
+      args << "--without-x" if build.without? "x11"
 
       # If LDFLAGS contains any -L options, configure sets LD_LIBRARY_PATH to
       # search those directories. Remove -LHOMEBREW_PREFIX/lib from LDFLAGS.

--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -58,7 +58,7 @@ class R < Formula
     if OS.linux?
       args << "--libdir=#{lib}" # avoid using lib64 on CentOS
       args << "--with-cairo" if build.with? "cairo"
-      args << "--without-x" if build.without? "x11"
+      args << "--without-x" if build.without? "xorg"
 
       # If LDFLAGS contains any -L options, configure sets LD_LIBRARY_PATH to
       # search those directories. Remove -LHOMEBREW_PREFIX/lib from LDFLAGS.


### PR DESCRIPTION
- Fix a bug that `--without-xorg` is ignored because `--with-x` is default.
- Add `:recommended` attribute to cairo

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
