### PR TITLE
atk: force installation in lib folder

### DIFF
--- a/Formula/atk.rb
+++ b/Formula/atk.rb
@@ -23,7 +23,7 @@ class Atk < Formula
     ENV.refurbish_args
 
     mkdir "build" do
-      system "meson", "--prefix=#{prefix}", ".."
+      system "meson", "--prefix=#{prefix}", *("--libdir=#{lib}" unless OS.mac?), ".."
       system "ninja"
       system "ninja", "install"
     end


### PR DESCRIPTION
This prevents meson to try to be too clever on centos
and install stuff in lib64. We do not support multilib builds
and everything should go into the lib folder.