### PR TITLE
at-spi2-atk: force installation in lib folder

### DIFF
--- a/Formula/at-spi2-atk.rb
+++ b/Formula/at-spi2-atk.rb
@@ -24,7 +24,7 @@ class AtSpi2Atk < Formula
     ENV.refurbish_args
 
     mkdir "build" do
-      system "meson", "--prefix=#{prefix}", ".."
+      system "meson", "--prefix=#{prefix}", *("--libdir=#{lib}" unless OS.mac?), ".."
       system "ninja"
       system "ninja", "install"
     end


### PR DESCRIPTION
This prevents meson to try to be too clever on centos
and install stuff in lib64. We do not support multilib builds
and everything should go into the lib folder.