### PR TITLE
gdbm: add GNU_SOURCE flag

### DIFF
--- a/Formula/gdbm.rb
+++ b/Formula/gdbm.rb
@@ -28,8 +28,13 @@ class Gdbm < Formula
       --without-readline
       --prefix=#{prefix}
     ]
-
-    args << "--enable-libgdbm-compat" if build.with? "libgdbm-compat"
+    
+    # GDBM uses some non-standard GNU extensions,
+    # enabled with -D_GNU_SOURCE.  See:
+    #   https://patchwork.ozlabs.org/patch/771300/
+    #   https://stackoverflow.com/questions/5582211
+    #   https://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html
+    args << "CPPFLAGS=-D_GNU_SOURCE --enable-libgdbm-compat" if build.with? "libgdbm-compat"
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/gdbm.rb
+++ b/Formula/gdbm.rb
@@ -28,13 +28,17 @@ class Gdbm < Formula
       --without-readline
       --prefix=#{prefix}
     ]
-    
+
+    args << "--enable-libgdbm-compat" if build.with? "libgdbm-compat"
+
     # GDBM uses some non-standard GNU extensions,
     # enabled with -D_GNU_SOURCE.  See:
     #   https://patchwork.ozlabs.org/patch/771300/
     #   https://stackoverflow.com/questions/5582211
     #   https://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html
-    args << "CPPFLAGS=-D_GNU_SOURCE --enable-libgdbm-compat" if build.with? "libgdbm-compat"
+    #
+    # Fix error: unknown type name 'blksize_t'
+    args << "CPPFLAGS=-D_GNU_SOURCE" unless OS.mac? || build.bottle?
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
Like the Spack Package:
https://github.com/citibeth/spack/blob/121306d9bbbeb1c69969a9ef039a622193c70534/var/spack/repos/builtin/packages/gdbm/package.py

- [X] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
