### PR TITLE
homebrew_core: Move a comma in tap_migrations.json

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -35,9 +35,9 @@
   "quassel": "homebrew/cask",
   "sqlitebrowser": "homebrew/cask",
   "transmission-remote-gtk": "homebrew/cask/transmission-remote-gui",
-  "tuntap": "homebrew/cask"
+  "tuntap": "homebrew/cask",
   "iotop": "linuxbrew/extra",
   "libpipeline": "linuxbrew/extra",
   "man-db": "linuxbrew/extra",
-  "strace": "linuxbrew/extra",
+  "strace": "linuxbrew/extra"
 }


### PR DESCRIPTION
Fixes Linuxbrew/brew#715

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
  > I only found instructions there related to formulae.
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
  > This issue is with Linuxbrew/homebrew-core, not with a formula.
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
  > This issue is with Linuxbrew/homebrew-core, not with a formula.

-----
