### PR TITLE
texlive 20180617: update sha256 in the formula

### DIFF
--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -2,8 +2,8 @@ class Texlive < Formula
   desc "TeX Live is a free software distribution for the TeX typesetting system"
   homepage "https://www.tug.org/texlive/"
   url "http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"
-  version "20180119"
-  sha256 "c5fe7d8747bd6968b83fa2028cbeaf87c0d4e7de69d671930b086e3ac2b2a287"
+  version "20180615"
+  sha256 "6821dc2ffa7b6272b1ef1366d61875c63a38d6d4c3385f1e20255f77baa3f0c2"
   # tag "linuxbrew"
 
   bottle do

--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -7,7 +7,6 @@ class Texlive < Formula
   # tag "linuxbrew"
 
   bottle do
-    sha256 "d8411a57a68358655861ce001f53807cee2c973cd8bd552da912180965d21aa4" => :x86_64_linux
   end
 
   option "with-full", "install everything"

--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -2,8 +2,8 @@ class Texlive < Formula
   desc "TeX Live is a free software distribution for the TeX typesetting system"
   homepage "https://www.tug.org/texlive/"
   url "http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"
-  version "20180615"
-  sha256 "6821dc2ffa7b6272b1ef1366d61875c63a38d6d4c3385f1e20255f77baa3f0c2"
+  version "20180617"
+  sha256 "4140038ec9a52dba1f43445df01ac98d717e3e654586b08f30336568b3287e88"
   # tag "linuxbrew"
 
   bottle do


### PR DESCRIPTION
`texlive` was updated to 20180615, so I rewrote the sha256 value in the `texlive` formula.
I've checked the new sha256 in the following step:

```
$ wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz
$ tar tf install-tl-unx.tar.gz | head -n1
install-tl-20180615/
$ sha256sum install-tl-unx.tar.gz 
6821dc2ffa7b6272b1ef1366d61875c63a38d6d4c3385f1e20255f77baa3f0c2  install-tl-unx.tar.gz
```
I'm not familiar with homebrew formulae, so I don't know whether I should touch the sha256 value in `bottle` closure.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Sorry, I didn't use `brew bump-formula-pr`. If this is inappropriate, I'd like someone to update the sha256 value...
