### PR TITLE
Fix lsof to build on linux

### DIFF
--- a/Formula/lsof.rb
+++ b/Formula/lsof.rb
@@ -23,20 +23,24 @@ class Lsof < Formula
     sha256 "b4e361c7ee2769bbafcb38cea2fc27f14f33667208eb1d143c71fd5ba2ae857e" => :x86_64_linux # glibc 2.19
   end
 
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/c3acbb8/lsof/lsof-489-darwin-compile-fix.patch"
-    sha256 "997d8c147070987350fc12078ce83cd6e9e159f757944879d7e4da374c030755"
+  if OS.mac?
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/c3acbb8/lsof/lsof-489-darwin-compile-fix.patch"
+      sha256 "997d8c147070987350fc12078ce83cd6e9e159f757944879d7e4da374c030755"
+    end
   end
 
   def install
-    ENV["LSOF_INCLUDE"] = "#{MacOS.sdk_path}/usr/include"
+    if OS.mac?
+      ENV["LSOF_INCLUDE"] = "#{MacOS.sdk_path}/usr/include"
 
-    # Source hardcodes full header paths at /usr/include
-    inreplace %w[
-      dialects/darwin/kmem/dlsof.h
-      dialects/darwin/kmem/machine.h
-      dialects/darwin/libproc/machine.h
-    ], "/usr/include", "#{MacOS.sdk_path}/usr/include"
+      # Source hardcodes full header paths at /usr/include
+      inreplace %w[
+        dialects/darwin/kmem/dlsof.h
+        dialects/darwin/kmem/machine.h
+        dialects/darwin/libproc/machine.h
+      ], "/usr/include", "#{MacOS.sdk_path}/usr/include"
+    end
 
     mv "00README", "README"
     system "./Configure", "-n", `uname -s`.chomp.downcase


### PR DESCRIPTION
Put an `if OS.mac?` guard around some mac specific patching that was breaking `lsof` compilation on Linux.