### PR TITLE
use a non-oracle mirror of java (and update)

### DIFF
--- a/Formula/jdk.rb
+++ b/Formula/jdk.rb
@@ -14,7 +14,6 @@ class Jdk < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "0701a22799493a1989ce113a5c3e43c0e1a140f33733ff7cc04c91257f456c6d" => :x86_64_linux
   end
 
   def install

--- a/Formula/jdk.rb
+++ b/Formula/jdk.rb
@@ -1,20 +1,13 @@
-class JdkDownloadStrategy < CurlDownloadStrategy
-  def _curl_opts
-    super << "--cookie" << "oraclelicense=accept-securebackup-cookie"
-  end
-end
-
 class Jdk < Formula
-  desc "Java Platform, Standard Edition Development Kit (JDK)."
+  desc "Java Platform, Standard Edition Development Kit (JDK)"
   homepage "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
   # tag "linuxbrew"
 
-  version "9.0.1+11"
+  version "9.0.4"
   version_scheme 1
   if OS.linux?
-    url "http://download.oracle.com/otn-pub/java/jdk/9.0.1+11/jdk-9.0.1_linux-x64_bin.tar.gz",
-      :using => JdkDownloadStrategy
-    sha256 "2cdaf0ff92d0829b510edd883a4ac8322c02f2fc1beae95d048b6716076bc014"
+    url "http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-9.0.4_linux-x64_bin.tar.gz"
+    sha256 "90c4ea877e816e3440862cfa36341bc87d05373d53389ec0f2d54d4e8c95daa2"
   elsif OS.mac?
     url "http://java.com/"
   end
@@ -30,10 +23,10 @@ class Jdk < Formula
   end
 
   def caveats; <<~EOS
-      By installing and using JDK you agree to the
-      Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX
-      http://www.oracle.com/technetwork/java/javase/terms/license/index.html
-    EOS
+    By installing and using JDK you agree to the
+    Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX
+    http://www.oracle.com/technetwork/java/javase/terms/license/index.html
+  EOS
   end
 
   test do

--- a/Formula/jdk@8.rb
+++ b/Formula/jdk@8.rb
@@ -1,19 +1,12 @@
-class JdkDownloadStrategy < CurlDownloadStrategy
-  def _curl_opts
-    super << "--cookie" << "oraclelicense=accept-securebackup-cookie"
-  end
-end
-
 class JdkAT8 < Formula
-  desc "Java Platform, Standard Edition Development Kit (JDK)."
+  desc "Java Platform, Standard Edition Development Kit (JDK)"
   homepage "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
   # tag "linuxbrew"
 
-  version "1.8.0-151"
+  version "1.8.0-162"
   if OS.linux?
-    url "http://download.oracle.com/otn-pub/java/jdk/8u151-b12/e758a0de34e24606bca991d704f6dcbf/jdk-8u151-linux-x64.tar.gz",
-      :using => JdkDownloadStrategy
-    sha256 "c78200ce409367b296ec39be4427f020e2c585470c4eed01021feada576f027f"
+    url "http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-8u162-linux-x64.tar.gz"
+    sha256 "68ec82d47fd9c2b8eb84225b6db398a72008285fafc98631b1ff8d2229680257"
   elsif OS.mac?
     url "http://java.com/"
   end
@@ -33,10 +26,10 @@ class JdkAT8 < Formula
   end
 
   def caveats; <<~EOS
-      By installing and using JDK you agree to the
-      Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX
-      http://www.oracle.com/technetwork/java/javase/terms/license/index.html
-    EOS
+    By installing and using JDK you agree to the
+    Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX
+    http://www.oracle.com/technetwork/java/javase/terms/license/index.html
+  EOS
   end
 
   test do

--- a/Formula/jdk@8.rb
+++ b/Formula/jdk@8.rb
@@ -13,7 +13,6 @@ class JdkAT8 < Formula
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "5055f79e8b7048e0fd27795131599aa440b195edbb02425dcd7f9171308720d5" => :x86_64_linux
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
Closes #700 ?

- [ :heavy_check_mark: ] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ :heavy_check_mark:   ] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ :heavy_check_mark: ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ :x: ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
I fixed a couple issues, but there's still some outstanding. I don't think I can do anything about them however.

```
$ brew audit --strict jdk
jdk:
  * C: 8: col 6: Don't use OS.linux?; Homebrew/core only supports macOS
  * C: 11: col 9: Don't use OS.mac?; Homebrew/core only supports macOS
  * C: 21: col 54: Don't use OS.mac?; Homebrew/core only supports macOS
  * JARs were installed to "/home/buck/prefix/brew/opt/jdk/lib"
    Installing JARs to "lib" can cause conflicts between packages.
    For Java software, it is typically better for the formula to
    install to "libexec" and then symlink or wrap binaries into "bin".
    See "activemq", "jruby", etc. for examples.
    The offending files are:
      /home/buck/prefix/brew/opt/jdk/lib/jdk.javaws.jar
            /home/buck/prefix/brew/opt/jdk/lib/plugin-legacy.jar
            /home/buck/prefix/brew/opt/jdk/lib/java.jnlp.jar
            /home/buck/prefix/brew/opt/jdk/lib/deploy.jar
            /home/buck/prefix/brew/opt/jdk/lib/plugin.jar
            /home/buck/prefix/brew/opt/jdk/lib/jdk.deploy.jar
            /home/buck/prefix/brew/opt/jdk/lib/jdk.plugin.jar
            /home/buck/prefix/brew/opt/jdk/lib/jdk.plugin.dom.jar
            /home/buck/prefix/brew/opt/jdk/lib/javafx-swt.jar
            /home/buck/prefix/brew/opt/jdk/lib/ant-javafx.jar
            /home/buck/prefix/brew/opt/jdk/lib/jrt-fs.jar
            /home/buck/prefix/brew/opt/jdk/lib/javaws.jar
Error: 4 problems in 1 formula

$ brew audit --strict jdk@8
jdk@8:
  * C: 7: col 6: Don't use OS.linux?; Homebrew/core only supports macOS
  * C: 10: col 9: Don't use OS.mac?; Homebrew/core only supports macOS
  * C: 22: col 54: Don't use OS.mac?; Homebrew/core only supports macOS
  * JARs were installed to "/home/buck/prefix/brew/opt/jdk@8/lib"
    Installing JARs to "lib" can cause conflicts between packages.
    For Java software, it is typically better for the formula to
    install to "libexec" and then symlink or wrap binaries into "bin".
    See "activemq", "jruby", etc. for examples.
    The offending files are:
      /home/buck/prefix/brew/opt/jdk@8/lib/jconsole.jar
            /home/buck/prefix/brew/opt/jdk@8/lib/packager.jar
            /home/buck/prefix/brew/opt/jdk@8/lib/tools.jar
            /home/buck/prefix/brew/opt/jdk@8/lib/javafx-mx.jar
            /home/buck/prefix/brew/opt/jdk@8/lib/dt.jar
            /home/buck/prefix/brew/opt/jdk@8/lib/ant-javafx.jar
            /home/buck/prefix/brew/opt/jdk@8/lib/sa-jdi.jar
  * Non-executables were installed to "/home/buck/prefix/brew/opt/jdk@8/bin"
    The offending files are:
      /home/buck/prefix/brew/opt/jdk@8/bin/jmc.ini
Error: 5 problems in 1 formula
```