### PR TITLE
gcc: workaround https://github.com/Linuxbrew/brew/issues/724

### DIFF
--- a/Formula/gcc@6.rb
+++ b/Formula/gcc@6.rb
@@ -241,8 +241,11 @@ class GccAT6 < Formula
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 
-      # Locate the native system header dirs if user uses system glibc
-      unless glibc_installed
+      if glibc_installed
+        # https://github.com/Linuxbrew/brew/issues/724
+        system_header_dirs << glibc.opt_include
+      else
+        # Locate the native system header dirs if user uses system glibc
         target = Utils.popen_read(gcc, "-print-multiarch").chomp
         raise "command failed: #{gcc} -print-multiarch" if $CHILD_STATUS.exitstatus.nonzero?
         system_header_dirs += ["/usr/include/#{target}", "/usr/include"]

--- a/Formula/gcc@7.rb
+++ b/Formula/gcc@7.rb
@@ -222,8 +222,11 @@ class GccAT7 < Formula
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 
-      # Locate the native system header dirs if user uses system glibc
-      unless glibc_installed
+      if glibc_installed
+        # https://github.com/Linuxbrew/brew/issues/724
+        system_header_dirs << glibc.opt_include
+      else
+        # Locate the native system header dirs if user uses system glibc
         target = Utils.popen_read(gcc, "-print-multiarch").chomp
         raise "command failed: #{gcc} -print-multiarch" if $CHILD_STATUS.exitstatus.nonzero?
         system_header_dirs += ["/usr/include/#{target}", "/usr/include"]

--- a/Formula/gcc@8.rb
+++ b/Formula/gcc@8.rb
@@ -201,8 +201,11 @@ class GccAT8 < Formula
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 
-      # Locate the native system header dirs if user uses system glibc
-      unless glibc_installed
+      if glibc_installed
+        # https://github.com/Linuxbrew/brew/issues/724
+        system_header_dirs << glibc.opt_include
+      else
+        # Locate the native system header dirs if user uses system glibc
         target = Utils.popen_read(gcc, "-print-multiarch").chomp
         raise "command failed: #{gcc} -print-multiarch" if $CHILD_STATUS.exitstatus.nonzero?
         system_header_dirs += ["/usr/include/#{target}", "/usr/include"]


### PR DESCRIPTION
For gcc >= 6, passing -isystem flag will result to the include path
search order change. This causes issues for brew superenv, which passes
-isystem HOMEBREW_PREFIX/include to the compiler. For more detail,
please refer to issue https://github.com/Linuxbrew/brew/issues/724

Related upstream issue can be found at
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129

This workarounds this issue by passing brew glibc include path to the
end of search path.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
