### PR TITLE
pulseaudio: add a dependcy on Perl

### DIFF
--- a/Formula/pulseaudio.rb
+++ b/Formula/pulseaudio.rb
@@ -47,6 +47,11 @@ class Pulseaudio < Formula
     depends_on "libcap"
     depends_on "expat"
 
+    # Depends on XML::Parser
+    # Using the host's Perl interpreter to install XML::Parser fails when using brew's glibc.
+    # Use brew's Perl interpreter instead.
+    # See Linuxbrew/homebrew-core#8148
+    depends_on "perl" => :build
     resource "XML::Parser" do
       url "https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.44.tar.gz"
       sha256 "1ae9d07ee9c35326b3d9aad56eae71a6730a73a116b9fe9e8a4758b7cc033216"
@@ -84,6 +89,15 @@ class Pulseaudio < Formula
     end
 
     args << "--disable-nls" if build.without? "nls"
+
+    # Perl depends on gdbm.
+    # If the dependency of pulseaudio on perl is build-time only,
+    # pulseaudio detects and links gdbm at build-time, but cannot locate it at run-time.
+    # Thus, we have to
+    #  - specify not to use gdbm, or
+    #  - add a dependency on gdbm if gdbm is wanted (not implemented).
+    # See Linuxbrew/homebrew-core#8148
+    args << "--with-database=simple" unless OS.mac?
 
     if build.head?
       # autogen.sh runs bootstrap.sh then ./configure


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----

Fix #7914 at least in my environment, CentOS6, with brewed perl.

It seems that, for any reason, perl in libexec cannot find brewed libc and uses the system (OS) libc. It causes GLIBC version mismatch in an old environment such as CentOS6.

However, this fix seems to cancel #4499, so the build might fail if there is not brewed perl.
I think more suitable fix is needed.
Anyway, I'd like to provide information and see if this PR passes CI tests.