### PR TITLE
unixodbc: only apply keg_only on macOS

### DIFF
--- a/Formula/unixodbc.rb
+++ b/Formula/unixodbc.rb
@@ -13,7 +13,7 @@ class Unixodbc < Formula
 
   depends_on "libtool"
 
-  keg_only "shadows system iODBC header files" if MacOS.version < :mavericks
+  keg_only "shadows system iODBC header files" if OS.mac? && MacOS.version < :mavericks
 
   conflicts_with "virtuoso", :because => "Both install `isql` binaries."
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
