### PR TITLE
perl: Set C_INCLUDE_PATH in postinstall

### DIFF
--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -84,6 +84,7 @@ class Perl < Formula
     unless OS.mac?
       ENV.with_build_environment do
         ENV["PERL_MM_USE_DEFAULT"] = "1"
+        ENV["C_INCLUDE_PATH"] = Formula["perl"].lib/"perl5/#{version}/x86_64-linux-thread-multi/CORE"
         system bin/"cpan", "-i", "XML::Parser"
         system bin/"cpan", "-i", "XML::SAX"
       end


### PR DESCRIPTION
Regarding [issues#8597](https://github.com/Linuxbrew/homebrew-core/issues/8597), I add `ENV["C_INCLUDE_PATH"]`

[https://gist.github.com/37fa606fc3c4e56f6862f0c432fe1b8d](https://gist.github.com/37fa606fc3c4e56f6862f0c432fe1b8d)

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----