### PR TITLE
perl: Call setup_build_environment(self) [Linux]

### DIFF
--- a/Formula/perl.rb
+++ b/Formula/perl.rb
@@ -82,11 +82,11 @@ class Perl < Formula
     # brewed Perl. As a temporary measure, install critical CPAN modules to ensure
     # they are available. See https://github.com/Linuxbrew/homebrew-core/pull/1064
     unless OS.mac?
-      ENV.with_build_environment do
-        ENV["PERL_MM_USE_DEFAULT"] = "1"
-        system bin/"cpan", "-i", "XML::Parser"
-        system bin/"cpan", "-i", "XML::SAX"
-      end
+      ENV.activate_extensions!
+      ENV.setup_build_environment(self)
+      ENV["PERL_MM_USE_DEFAULT"] = "1"
+      system bin/"cpan", "-i", "XML::Parser"
+      system bin/"cpan", "-i", "XML::SAX"
     end
   end
 


### PR DESCRIPTION
Call `ENV.setup_build_environment(self)` rather than `ENV.with_build_environment`.

We recently enabled `ENV.refurbish_args` by default.
`brew postinstall` does not call `ENV.setup_build_environment`.
`perl` calls `ENV.with_build_environment` in `postinstall`.
`ENV.with_build_environment` calls `ENV.setup_build_environment(formula = nil)`.
`HOMEBREW_FORMULA_PREFIX` is set to `nil`.
`shims/super/cc` does not know which formula is being built.
The formula prefix is removed from the header and library search paths.