### PR TITLE
glibc, llvm@4, llvm@5: Use OS::Linux::Glibc.system_version rather than GlibcRequirement.system_version

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -7,7 +7,7 @@ class BrewedGlibcNotOlderRequirement < Requirement
 
   def message
     <<~EOS
-      Your system's glibc version is #{OS::Linux::Glibc.system_version}, and Linuxbrew's gcc version is #{Glibc.version}.
+      Your system's glibc version is #{OS::Linux::Glibc.system_version}, and Linuxbrew's glibc version is #{Glibc.version}.
       Installing a version of glibc that is older than your system's can break formulae installed from source.
     EOS
   end

--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -2,12 +2,12 @@ class BrewedGlibcNotOlderRequirement < Requirement
   fatal true
 
   satisfy(:build_env => false) do
-    Glibc.version >= GlibcRequirement.system_version
+    Glibc.version >= OS::Linux::Glibc.system_version
   end
 
   def message
     <<~EOS
-      Your system's glibc version is #{GlibcRequirement.system_version}, and Linuxbrew's gcc version is #{Glibc.version}.
+      Your system's glibc version is #{OS::Linux::Glibc.system_version}, and Linuxbrew's gcc version is #{Glibc.version}.
       Installing a version of glibc that is older than your system's can break formulae installed from source.
     EOS
   end

--- a/Formula/llvm@4.rb
+++ b/Formula/llvm@4.rb
@@ -79,7 +79,7 @@ class LlvmAT4 < Formula
 
   unless OS.mac?
     depends_on "gcc" # <atomic> is provided by gcc
-    depends_on "glibc" => (GlibcRequirement.system_version.to_f >= 2.19) ? :optional : :recommended
+    depends_on "glibc" => (OS::Linux::Glibc.system_version.to_f >= 2.19) ? :optional : :recommended
     depends_on "binutils" # needed for gold and strip
     depends_on "libedit" # llvm requires <histedit.h>
     depends_on "ncurses"

--- a/Formula/llvm@5.rb
+++ b/Formula/llvm@5.rb
@@ -110,7 +110,7 @@ class LlvmAT5 < Formula
 
   unless OS.mac?
     depends_on "gcc" # <atomic> is provided by gcc
-    depends_on "glibc" => (GlibcRequirement.system_version.to_f >= 2.19) ? :optional : :recommended
+    depends_on "glibc" => (OS::Linux::Glibc.system_version.to_f >= 2.19) ? :optional : :recommended
     depends_on "binutils" # needed for gold and strip
     depends_on "libedit" # llvm requires <histedit.h>
     depends_on "ncurses"


### PR DESCRIPTION
I'm planning to remove `GlibcRequirement`. It has little purpose, since `default_formula` has been deprecated.