### PR TITLE
Travis CI: check style of the core tap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,8 +104,8 @@ matrix:
 script:
   - brew test-bot --tap=linuxbrew/core --fast
   - brew style linuxbrew/core
-  - brew audit -D --except=revision_and_version_scheme $(cd $(brew --repo linuxbrew/core)/Formula && ls *.rb)
-  - brew audit -D --except=revision_and_version_scheme --strict $(cd $(brew --repo linuxbrew/core)/Formula && ls *.rb) || true
+  - brew audit -D --except=revision_and_version_scheme $(ls $(brew --repo linuxbrew/core)/Formula/*.rb)
+  - brew audit -D --except=revision_and_version_scheme --strict $(ls $(brew --repo linuxbrew/core)/Formula/*.rb) || true
   - brew readall --aliases --syntax linuxbrew/core
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ matrix:
     - os: linux
 
 script:
-  - brew test-bot --bintray-org=linuxbrew --git-name=LinuxbrewTestBot --git-email=testbot@linuxbrew.sh
+  - brew style linuxbrew/core
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,8 +104,8 @@ matrix:
 script:
   - brew test-bot --tap=linuxbrew/core --fast
   - brew style linuxbrew/core
-  - brew audit $(cd $(brew --repo linuxbrew/core)/Formula; ls *.rb | sed 's|.rb$||')
-  - brew audit --strict $(cd $(brew --repo linuxbrew/core)/Formula; ls *.rb | sed 's|.rb$||') || true
+  - brew audit -D --except=revision_and_version_scheme $(cd $(brew --repo linuxbrew/core)/Formula && ls *.rb)
+  - brew audit -D --except=revision_and_version_scheme --strict $(cd $(brew --repo linuxbrew/core)/Formula && ls *.rb) || true
   - brew readall --aliases --syntax linuxbrew/core
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,11 @@ matrix:
     - os: linux
 
 script:
+  - brew test-bot --tap=linuxbrew/core --fast
   - brew style linuxbrew/core
+  - brew audit $(cd $(brew --repo linuxbrew/core)/Formula; ls *.rb | sed 's|.rb$||')
+  - brew audit --strict $(cd $(brew --repo linuxbrew/core)/Formula; ls *.rb | sed 's|.rb$||') || true
+  - brew readall --aliases --syntax linuxbrew/core
 
 notifications:
   slack:


### PR DESCRIPTION
Instead of running `test-bot`, use Travis to do a simpler task of checking the style of the linuxbrew/core tap.