### PR TITLE
Feature/fix mysql@5.6

### DIFF
--- a/Formula/mysql@5.6.rb
+++ b/Formula/mysql@5.6.rb
@@ -26,8 +26,9 @@ class MysqlAT56 < Formula
   deprecated_option "with-tests" => "with-test"
 
   depends_on "cmake" => :build
-  depends_on "pidof" unless MacOS.version >= :mountain_lion
+  depends_on "pidof" unless MacOS.version >= :mountain_lion || !OS.mac?
   depends_on "openssl"
+  depends_on "libedit" unless OS.mac?
 
   def datadir
     var/"mysql"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?

Yes. although `brew audit --strict` still does not like `OS.mac?`

```
mysql@5.6:
  * C: 29: col 65: Don't use OS.mac?; Homebrew/core only supports macOS
  * C: 31: col 31: Don't use OS.mac?; Homebrew/core only supports macOS
```
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?

Yes
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

Yes.

Installation
```
$ brew install --build-from-source Formula/mysql@5.6.rb 
==> Downloading https://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-5.6.41.tar.gz
Already downloaded: /home/dennis/.cache/Homebrew/mysql@5.6--5.6.41.tar.gz
==> cmake . -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG -DCMAKE_INSTALL_PREFIX=/home/linuxbrew/.linuxbrew/Cellar/mysql@5.6/5.6.41 -DCMAKE_BUILD_TYPE=Release -DCM
==> make
==> make install
==> ./mysql-test-run.pl status --vardir=/tmp/d20180818-10688-v03qfg
==> Caveats
A "/etc/my.cnf" from another install may interfere with a Homebrew-built
server starting up correctly.

MySQL is configured to only allow connections from localhost by default

To connect:
    mysql -uroot

mysql@5.6 is keg-only, which means it was not symlinked into /home/linuxbrew/.linuxbrew,
because this is an alternate version of another formula.

If you need to have mysql@5.6 first in your PATH run:
  echo 'export PATH="/home/linuxbrew/.linuxbrew/opt/mysql@5.6/bin:$PATH"' >> ~/.bash_profile

For compilers to find mysql@5.6 you may need to set:
  export LDFLAGS="-L/home/linuxbrew/.linuxbrew/opt/mysql@5.6/lib"
  export CPPFLAGS="-I/home/linuxbrew/.linuxbrew/opt/mysql@5.6/include"

==> Summary
🍺  /home/linuxbrew/.linuxbrew/Cellar/mysql@5.6/5.6.41: 340 files, 176.5MB, built in 10 minutes 15 seconds
```
Test
```
$ brew test Formula/mysql@5.6.rb
Testing mysql@5.6
==> /home/linuxbrew/.linuxbrew/Cellar/mysql@5.6/5.6.41/bin/mysql_install_db --user=dennis --basedir=/home/linuxbrew/.linuxbrew/Cellar/mysql@5.6/5.6.41 --datadir=/tmp/d20180818-29428-1g2
2018-08-18 22:02:10 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2018-08-18 22:02:10 0 [Note] --secure-file-priv is set to NULL. Operations related to importing and exporting data are disabled
2018-08-18 22:02:10 0 [Note] /home/linuxbrew/.linuxbrew/Cellar/mysql@5.6/5.6.41/bin/mysqld (mysqld 5.6.41) starting as process 29495 ...
2018-08-18 22:02:10 29495 [Warning] Buffered warning: Changed limits: max_open_files: 1024 (requested 5000)

2018-08-18 22:02:10 29495 [Warning] Buffered warning: Changed limits: table_open_cache: 431 (requested 2000)

2018-08-18 22:02:10 29495 [Note] Plugin 'FEDERATED' is disabled.
2018-08-18 22:02:10 29495 [Note] InnoDB: Using atomics to ref count buffer pool pages
2018-08-18 22:02:10 29495 [Note] InnoDB: The InnoDB memory heap is disabled
2018-08-18 22:02:10 29495 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
2018-08-18 22:02:10 29495 [Note] InnoDB: Memory barrier is not used
2018-08-18 22:02:10 29495 [Note] InnoDB: Compressed tables use zlib 1.2.3
2018-08-18 22:02:10 29495 [Note] InnoDB: Using CPU crc32 instructions
2018-08-18 22:02:10 29495 [Note] InnoDB: Initializing buffer pool, size = 128.0M
2018-08-18 22:02:10 29495 [Note] InnoDB: Completed initialization of buffer pool
2018-08-18 22:02:10 29495 [Note] InnoDB: Highest supported file format is Barracuda.
2018-08-18 22:02:10 29495 [Note] InnoDB: 128 rollback segment(s) are active.
2018-08-18 22:02:10 29495 [Note] InnoDB: Waiting for purge to start
2018-08-18 22:02:10 29495 [Note] InnoDB: 5.6.41 started; log sequence number 1625987
2018-08-18 22:02:10 29495 [Warning] No existing UUID has been found, so we assume that this is the first time that this server has been started. Generating a new UUID: 97a5fa93-a321-11e8-8547-8c705a7d35ec.
2018-08-18 22:02:10 29495 [Note] RSA private key file not found: /tmp/d20180818-29428-1g23lgx//private_key.pem. Some authentication plugins will not work.
2018-08-18 22:02:10 29495 [Note] RSA public key file not found: /tmp/d20180818-29428-1g23lgx//public_key.pem. Some authentication plugins will not work.
2018-08-18 22:02:10 29495 [Note] Server hostname (bind-address): '127.0.0.1'; port: 3306
2018-08-18 22:02:10 29495 [Note]   - '127.0.0.1' resolves to '127.0.0.1';
2018-08-18 22:02:10 29495 [Note] Server socket created on IP: '127.0.0.1'.
2018-08-18 22:02:10 29495 [Warning] Insecure configuration for --pid-file: Location '/tmp' in the path is accessible to all OS users. Consider choosing a different directory.
2018-08-18 22:02:10 29495 [Note] Event Scheduler: Loaded 0 events
2018-08-18 22:02:10 29495 [Note] /home/linuxbrew/.linuxbrew/Cellar/mysql@5.6/5.6.41/bin/mysqld: ready for connections.
Version: '5.6.41'  socket: '/tmp/mysql.sock'  port: 3306  Homebrew
==> curl 127.0.0.1:3306
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   110    0   110    0     0   107k      0 --:--:-- --:--:-- --:--:--  107k
```
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

As mentioned above, I've received warnings about the usage of `OS.mac?`
```
mysql@5.6:
  * C: 29: col 65: Don't use OS.mac?; Homebrew/core only supports macOS
  * C: 31: col 31: Don't use OS.mac?; Homebrew/core only supports macOS
```
-----
