### PR TITLE
openjdk (new formula)

### DIFF
--- a/Aliases/openjdk@8
+++ b/Aliases/openjdk@8
@@ -1,0 +1,1 @@
+../Formula/openjdk.rb

--- a/Formula/openjdk.rb
+++ b/Formula/openjdk.rb
@@ -1,0 +1,36 @@
+class Openjdk < Formula
+  desc "Java Development Kit"
+  homepage "https://github.com/ojdkbuild/"
+  # tag "linuxbrew"
+
+  version "1.8.0-181"
+  if OS.mac?
+    url "http://java.com/"
+  else
+    url "https://github.com/ojdkbuild/contrib_jdk8u-ci/releases/download/jdk8u181-b13/jdk-8u181-ojdkbuild-linux-x64.zip"
+    sha256 "fe5f5f8870e3195b0ee4c25c597b990ebbe8e667f3a345ff0afc49a8ff212dae"
+  end
+
+  depends_on :linux
+
+  def install
+    prefix.install Dir["*"]
+    share.mkdir
+    share.install prefix/"man"
+  end
+
+  test do
+    (testpath/"Hello.java").write <<~EOS
+      class Hello
+      {
+        public static void main(String[] args)
+        {
+          System.out.println("Hello Homebrew");
+        }
+      }
+    EOS
+    system bin/"javac", "Hello.java"
+    assert_predicate testpath/"Hello.class", :exist?, "Failed to compile Java program!"
+    assert_equal "Hello Homebrew\n", shell_output("#{bin}/java Hello")
+  end
+end

--- a/Formula/openjdk@10.rb
+++ b/Formula/openjdk@10.rb
@@ -1,0 +1,36 @@
+class OpenjdkAT10 < Formula
+  desc "Java Development Kit"
+  homepage "http://jdk.java.net/10/"
+  # tag "linuxbrew"
+
+  version "10.0.2"
+  if OS.mac?
+    url "http://java.com/"
+  else
+    url "https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz"
+    sha256 "f3b26abc9990a0b8929781310e14a339a7542adfd6596afb842fa0dd7e3848b2"
+  end
+
+  depends_on :linux
+
+  def install
+    prefix.install Dir["*"]
+    share.mkdir
+    share.install prefix/"man"
+  end
+
+  test do
+    (testpath/"Hello.java").write <<~EOS
+      class Hello
+      {
+        public static void main(String[] args)
+        {
+          System.out.println("Hello Homebrew");
+        }
+      }
+    EOS
+    system bin/"javac", "Hello.java"
+    assert_predicate testpath/"Hello.class", :exist?, "Failed to compile Java program!"
+    assert_equal "Hello Homebrew\n", shell_output("#{bin}/java Hello")
+  end
+end

--- a/Formula/openjdk@9.rb
+++ b/Formula/openjdk@9.rb
@@ -1,0 +1,36 @@
+class OpenjdkAT9 < Formula
+  desc "Java Development Kit"
+  homepage "http://jdk.java.net/archive/"
+  # tag "linuxbrew"
+
+  version "9.0.4"
+  if OS.mac?
+    url "http://java.com/"
+  else
+    url "https://download.java.net/java/GA/jdk9/9.0.4/binaries/openjdk-9.0.4_linux-x64_bin.tar.gz"
+    sha256 "39362fb9bfb341fcc802e55e8ea59f4664ca58fd821ce956d48e1aa4fb3d2dec"
+  end
+
+  depends_on :linux
+
+  def install
+    prefix.install Dir["*"]
+    share.mkdir
+    share.install prefix/"man"
+  end
+
+  test do
+    (testpath/"Hello.java").write <<~EOS
+      class Hello
+      {
+        public static void main(String[] args)
+        {
+          System.out.println("Hello Homebrew");
+        }
+      }
+    EOS
+    system bin/"javac", "Hello.java"
+    assert_predicate testpath/"Hello.class", :exist?, "Failed to compile Java program!"
+    assert_equal "Hello Homebrew\n", shell_output("#{bin}/java Hello")
+  end
+end


### PR DESCRIPTION
Upgrade to jdk 10.0.2
The formula jdk.rb has been moved to jdk@9.rb
The alias to the current jdk has been renamed from  Aliases/jdk@9 to Aliases/jdk@10.rb