### PR TITLE
Fix style violations for Linuxbrew

### DIFF
--- a/Formula/checkstyle.rb
+++ b/Formula/checkstyle.rb
@@ -6,6 +6,8 @@ class Checkstyle < Formula
 
   bottle :unneeded
 
+  depends_on "jdk" unless OS.mac?
+
   def install
     libexec.install "checkstyle-#{version}-all.jar"
     bin.write_jar_script libexec/"checkstyle-#{version}-all.jar", "checkstyle"
@@ -18,6 +20,6 @@ class Checkstyle < Formula
     output = Utils.popen_read("#{bin}/checkstyle -c /sun_checks.xml #{path}")
     errors = output.lines.select { |line| line.start_with?("[ERROR] #{path}") }
     assert_match "#{path}:1:17: '{' is not preceded with whitespace.", errors.join(" ")
-    assert_equal errors.size, $?.exitstatus
+    assert_equal errors.size, $CHILD_STATUS.exitstatus
   end
 end

--- a/Formula/checkstyle.rb
+++ b/Formula/checkstyle.rb
@@ -6,7 +6,7 @@ class Checkstyle < Formula
 
   bottle :unneeded
 
-  depends_on "jdk" unless OS.mac?
+  depends_on :java unless OS.mac?
 
   def install
     libexec.install "checkstyle-#{version}-all.jar"

--- a/Formula/ed.rb
+++ b/Formula/ed.rb
@@ -21,7 +21,6 @@ class Ed < Formula
     option "without-default-names", "Prepend 'g' to the binaries"
   end
 
-
   def install
     ENV.deparallelize
 

--- a/Formula/jdk@7.rb
+++ b/Formula/jdk@7.rb
@@ -26,7 +26,7 @@ class JdkAT7 < Formula
     By installing and using JDK you agree to the
       Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX
       http://www.oracle.com/technetwork/java/javase/terms/license/index.html
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/jdk@8.rb
+++ b/Formula/jdk@8.rb
@@ -8,7 +8,7 @@ class JdkAT8 < Formula
     url "http://java.com/"
   else
     url "http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-8u181-linux-x64.tar.gz",
-      cookies: {
+      :cookies => {
         "oraclelicense" => "accept-securebackup-cookie",
       }
     sha256 "1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3"

--- a/Formula/llvm@4.rb
+++ b/Formula/llvm@4.rb
@@ -273,7 +273,7 @@ class LlvmAT4 < Formula
       end
       system "make"
       system "make", "install"
-      system "make", "install-xcode-toolchain" if build.with? "toolchain" && OS.mac?
+      system "make", "install-xcode-toolchain" if build.with?("toolchain") && OS.mac?
     end
 
     (share/"clang/tools").install Dir["tools/clang/tools/scan-{build,view}"]

--- a/cmd/brew-strip.rb
+++ b/cmd/brew-strip.rb
@@ -3,7 +3,7 @@
 #:
 #:    If `--all` is passed, strip all installed formulae.
 
-require File.expand_path("../strip", __FILE__)
+require File.expand_path("strip", __dir__)
 
 odie "Command not found: strip" unless which "strip"
 formulae = if ARGV.include?("--all") || ARGV.include?("--installed")


### PR DESCRIPTION
1. Fix style violations reported by `brew style linuxbrew/core`
2. `checkstyle` - depends on "jdk" for Linuxbrew, because it assumes presence of executable `java` in PATH.