### PR TITLE
Fix audit warnings for (some) linuxbrew-only formulae

### DIFF
--- a/Formula/alsa-lib.rb
+++ b/Formula/alsa-lib.rb
@@ -1,5 +1,5 @@
 class AlsaLib < Formula
-  desc "Provides audio and MIDI functionality to the Linux operating system."
+  desc "Provides audio and MIDI functionality to the Linux operating system"
   homepage "http://www.alsa-project.org/"
   url "ftp://ftp.alsa-project.org/pub/lib/alsa-lib-1.1.2.tar.bz2"
   sha256 "d38dacd9892b06b8bff04923c380b38fb2e379ee5538935ff37e45b395d861d6"

--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -12,10 +12,12 @@ class Elfutils < Formula
   option "with-valgrind", "Run tests with valgrind"
 
   depends_on "xz"
-  depends_on "bzip2" unless OS.mac?
-  depends_on "zlib" unless OS.mac?
   depends_on "valgrind" => [:build, :optional]
-  depends_on "m4" => :build
+  unless OS.mac?
+    depends_on "m4" => :build
+    depends_on "bzip2"
+    depends_on "zlib"
+  end
 
   conflicts_with "libelf", :because => "both install `libelf.a` library"
 
@@ -55,6 +57,7 @@ class Elfutils < Formula
       rm_f file
       Pathname(file).write("exit 77", :perm => 0755)
     end
+
     system "make", "check"
     system "make", "install"
   end

--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -36,8 +36,9 @@ class Elfutils < Formula
 
     # Some tests in elfutils require that the package
     # is built with `-g` flag which if filtered out
-    # by the superenv. Instead of re-enabling this flag
-    # for elfutils, we disable the tests that fail.
+    # by the superenv. Instead of hacking around to
+    # re-enable the flag for elfutils, we disable the
+    # tests that require it.
     skip_tests = %w[
       backtrace-data
       backtrace-dwarf
@@ -52,8 +53,7 @@ class Elfutils < Formula
     skip_tests.each do |test|
       file = "tests/run-#{test}.sh"
       rm_f file
-      Pathname(file).write "exit 77"
-      chmod 0755, file
+      Pathname(file).write("exit 77", perm: 0755)
     end
     system "make", "check"
     system "make", "install"

--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -17,7 +17,7 @@ class Elfutils < Formula
   depends_on "valgrind" => [:build, :optional]
   depends_on "m4" => :build
 
-  conflicts_with "libelf",  :because => "both install `libelf.a` library"
+  conflicts_with "libelf", :because => "both install `libelf.a` library"
 
   fails_with :clang do
     build 700

--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -15,6 +15,7 @@ class Elfutils < Formula
   depends_on "bzip2" unless OS.mac?
   depends_on "zlib" unless OS.mac?
   depends_on "valgrind" => [:build, :optional]
+  depends_on "m4" => :build
 
   conflicts_with "libelf",  :because => "both install `libelf.a` library"
 

--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -34,6 +34,10 @@ class Elfutils < Formula
       *("--enable-valgrind" if build.with? "valgrind")
     system "make"
 
+    # Some tests in elfutils require that the package
+    # is built with `-g` flag which if filtered out
+    # by the superenv. Instead of re-enabling this flag
+    # for elfutils, we disable the tests that fail.
     skip_tests = %w[
       backtrace-data
       backtrace-dwarf

--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -33,6 +33,24 @@ class Elfutils < Formula
       "--prefix=#{prefix}",
       *("--enable-valgrind" if build.with? "valgrind")
     system "make"
+
+    skip_tests = %w[
+      backtrace-data
+      backtrace-dwarf
+      backtrace-native-core
+      backtrace-native
+      deleted
+      disasm-x86
+      readelf-self
+      strip-reloc
+      strip-strmerge
+    ]
+    skip_tests.each do |test|
+      file = "tests/run-#{test}.sh"
+      rm_f file
+      Pathname(file).write "exit 77"
+      chmod 0755, file
+    end
     system "make", "check"
     system "make", "install"
   end

--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -53,7 +53,7 @@ class Elfutils < Formula
     skip_tests.each do |test|
       file = "tests/run-#{test}.sh"
       rm_f file
-      Pathname(file).write("exit 77", perm: 0755)
+      Pathname(file).write("exit 77", :perm => 0755)
     end
     system "make", "check"
     system "make", "install"

--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -1,5 +1,5 @@
 class Elfutils < Formula
-  desc "Libraries and utilities for handling ELF objects."
+  desc "Libraries and utilities for handling ELF objects"
   homepage "https://fedorahosted.org/elfutils/"
   url "https://sourceware.org/elfutils/ftp/0.168/elfutils-0.168.tar.bz2"
   sha256 "b88d07893ba1373c7dd69a7855974706d05377766568a7d9002706d5de72c276"

--- a/Formula/jdk@7.rb
+++ b/Formula/jdk@7.rb
@@ -1,14 +1,14 @@
 class JdkAT7 < Formula
   desc "Java Platform, Standard Edition Development Kit (JDK)"
-  homepage "http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html"
+  homepage "https://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html"
   # tag "linuxbrew"
 
   version "1.7.0-80"
   if OS.linux?
-    url "http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-7u80-linux-x64.tar.gz"
+    url "https://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-7u80-linux-x64.tar.gz"
     sha256 "bad9a731639655118740bee119139c1ed019737ec802a630dd7ad7aab4309623"
   elsif OS.mac?
-    url "http://java.com/"
+    url "https://java.com/"
   end
 
   bottle :unneeded

--- a/Formula/jdk@7.rb
+++ b/Formula/jdk@7.rb
@@ -1,5 +1,5 @@
 class JdkAT7 < Formula
-  desc "Java Platform, Standard Edition Development Kit (JDK)."
+  desc "Java Platform, Standard Edition Development Kit (JDK)"
   homepage "http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html"
   # tag "linuxbrew"
 

--- a/Formula/libfuse.rb
+++ b/Formula/libfuse.rb
@@ -1,5 +1,5 @@
 class Libfuse < Formula
-  desc "Reference implementation of the Linux FUSE interface."
+  desc "Reference implementation of the Linux FUSE interface"
   homepage "https://github.com/libfuse/libfuse"
   url "https://github.com/libfuse/libfuse/archive/fuse_2_9_5.tar.gz"
   sha256 "ccea9c00f7572385e9064bc55b2bfefd8d34de487ba16d9eb09672202b5440ec"
@@ -35,6 +35,6 @@ class Libfuse < Formula
         return fuse_main(argc, argv, &ops, NULL);
       }
     EOS
-    system "$CC $CPPFLAGS -DFUSE_USE_VERSION=26 -D_FILE_OFFSET_BITS=64 fuse-test.c $LDFLAGS -lfuse"
+    system "$CC", "$CPPFLAGS", "-DFUSE_USE_VERSION=26", "-D_FILE_OFFSET_BITS=64", "fuse-test.c", "$LDFLAGS", "-lfuse"
   end
 end

--- a/Formula/libfuse.rb
+++ b/Formula/libfuse.rb
@@ -35,6 +35,6 @@ class Libfuse < Formula
         return fuse_main(argc, argv, &ops, NULL);
       }
     EOS
-    system "$CC", "$CPPFLAGS", "-DFUSE_USE_VERSION=26", "-D_FILE_OFFSET_BITS=64", "fuse-test.c", "$LDFLAGS", "-lfuse"
+    system ENV.cc, ENV["$CPPFLAGS"], "-DFUSE_USE_VERSION=26", "-D_FILE_OFFSET_BITS=64", "fuse-test.c", "$LDFLAGS", "-lfuse"
   end
 end

--- a/Formula/libgpm.rb
+++ b/Formula/libgpm.rb
@@ -3,9 +3,8 @@ class Libgpm < Formula
   homepage "https://www.nico.schottelius.org/software/gpm/"
   url "https://www.nico.schottelius.org/software/gpm/archives/gpm-1.20.7.tar.bz2"
   sha256 "f011b7dc7afb824e0a017b89b7300514e772853ece7fc4ee640310889411a48d"
-  # tag "linuxbrew"
-
   head "https://github.com/telmich/gpm.git"
+  # tag "linuxbrew"
 
   bottle do
     cellar :any

--- a/Formula/libgpm.rb
+++ b/Formula/libgpm.rb
@@ -1,16 +1,16 @@
 class Libgpm < Formula
-  desc "general purpose mouse"
+  desc "General-purpose mouse"
   homepage "http://www.nico.schottelius.org/software/gpm/"
   url "http://www.nico.schottelius.org/software/gpm/archives/gpm-1.20.7.tar.bz2"
   sha256 "f011b7dc7afb824e0a017b89b7300514e772853ece7fc4ee640310889411a48d"
   # tag "linuxbrew"
 
+  head "https://github.com/telmich/gpm.git"
+
   bottle do
     cellar :any
     sha256 "7aec47e93bf034b08d3376ce35e75c87e0dd4995917f5f0727b0297189e02af8" => :x86_64_linux # glibc 2.19
   end
-
-  head "https://github.com/telmich/gpm.git"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -21,7 +21,7 @@ class Libgpm < Formula
 
   patch :DATA
   patch do
-    url "https://patch-diff.githubusercontent.com/raw/telmich/gpm/pull/14.patch"
+    url "https://github.com/telmich/gpm/pull/14.patch?full_index=1"
     sha256 "53c7d470ccdad04a769223995c085e4b3d46f8931bc4febfa75bd7bd9519a937"
   end
 

--- a/Formula/libgpm.rb
+++ b/Formula/libgpm.rb
@@ -1,7 +1,7 @@
 class Libgpm < Formula
   desc "General-purpose mouse"
   homepage "http://www.nico.schottelius.org/software/gpm/"
-  url "http://www.nico.schottelius.org/software/gpm/archives/gpm-1.20.7.tar.bz2"
+  url "https://www.nico.schottelius.org/software/gpm/archives/gpm-1.20.7.tar.bz2"
   sha256 "f011b7dc7afb824e0a017b89b7300514e772853ece7fc4ee640310889411a48d"
   # tag "linuxbrew"
 

--- a/Formula/libgpm.rb
+++ b/Formula/libgpm.rb
@@ -22,7 +22,7 @@ class Libgpm < Formula
   patch :DATA
   patch do
     url "https://github.com/telmich/gpm/pull/14.patch?full_index=1"
-    sha256 "53c7d470ccdad04a769223995c085e4b3d46f8931bc4febfa75bd7bd9519a937"
+    sha256 "0bcee6127c9fcae7f515fc2adda621877cb19f741a8e99c400d044c8f01832c3"
   end
 
   def install

--- a/Formula/libgpm.rb
+++ b/Formula/libgpm.rb
@@ -1,6 +1,6 @@
 class Libgpm < Formula
   desc "General-purpose mouse"
-  homepage "http://www.nico.schottelius.org/software/gpm/"
+  homepage "https://www.nico.schottelius.org/software/gpm/"
   url "https://www.nico.schottelius.org/software/gpm/archives/gpm-1.20.7.tar.bz2"
   sha256 "f011b7dc7afb824e0a017b89b7300514e772853ece7fc4ee640310889411a48d"
   # tag "linuxbrew"

--- a/Formula/libprelude.rb
+++ b/Formula/libprelude.rb
@@ -19,8 +19,8 @@ class Libprelude < Formula
   depends_on "gnutls"
   depends_on "swig" => [:build, :recommended]
   depends_on "perl" => [:build, :optional]
-  depends_on "python" => [:build, :recommended]
-  depends_on "python3" => :recommended
+  depends_on "python@2" => [:build, :recommended]
+  depends_on "python" => :recommended
   depends_on "valgrind" => [:build, :recommended]
   depends_on "lua" => [:build, :optional]
   depends_on "ruby"

--- a/Formula/libtirpc.rb
+++ b/Formula/libtirpc.rb
@@ -1,8 +1,8 @@
 class Libtirpc < Formula
   desc "Port of Sun's Transport-Independent RPC library to Linux"
   homepage "https://sourceforge.net/projects/libtirpc/"
-  url "https://downloads.sourceforge.net/project/libtirpc/libtirpc/1.0.3/libtirpc-1.0.3.tar.bz2"
-  sha256 "86c3a78fc1bddefa96111dd233124c703b22a78884203c55c3e06b3be6a0fd5e"
+  url "https://downloads.sourceforge.net/project/libtirpc/libtirpc/1.0.1/libtirpc-1.0.1.tar.bz2"
+  sha256 "5156974f31be7ccbc8ab1de37c4739af6d9d42c87b1d5caf4835dda75fcbb89e"
   # tag "linuxbrew"
 
   bottle do

--- a/Formula/libtirpc.rb
+++ b/Formula/libtirpc.rb
@@ -2,7 +2,7 @@ class Libtirpc < Formula
   desc "Port of Sun's Transport-Independent RPC library to Linux"
   homepage "https://sourceforge.net/projects/libtirpc/"
   url "https://downloads.sourceforge.net/project/libtirpc/libtirpc/1.0.3/libtirpc-1.0.3.tar.bz2"
-  sha256 "251a85b3bac687974f360d3796048c20ded3bf0bd69e0d1cfd1db23d013f89ed"
+  sha256 "86c3a78fc1bddefa96111dd233124c703b22a78884203c55c3e06b3be6a0fd5e"
   # tag "linuxbrew"
 
   bottle do

--- a/Formula/libtirpc.rb
+++ b/Formula/libtirpc.rb
@@ -1,8 +1,8 @@
 class Libtirpc < Formula
   desc "Port of Sun's Transport-Independent RPC library to Linux"
   homepage "http://sourceforge.net/projects/libtirpc/"
-  url "https://downloads.sourceforge.net/project/libtirpc/libtirpc/1.0.1/libtirpc-1.0.1.tar.bz2"
-  sha256 "5156974f31be7ccbc8ab1de37c4739af6d9d42c87b1d5caf4835dda75fcbb89e"
+  url "https://downloads.sourceforge.net/project/libtirpc/libtirpc/1.0.3/libtirpc-1.0.3.tar.bz2"
+  sha256 "86c3a78fc1bddefa96111dd233124c703b22a78884203c55c3e06b3be6a0fd5e"
   # tag "linuxbrew"
 
   bottle do
@@ -10,7 +10,7 @@ class Libtirpc < Formula
     sha256 "7c093d0948f7794df11cae0a0f0e974e8b0734d46beb2f7977db39d84aa16720" => :x86_64_linux # glibc 2.19
   end
 
-  depends_on "krb5" => :optional unless OS.mac?
+  depends_on "krb5"
 
   def install
     system "./configure",
@@ -19,5 +19,22 @@ class Libtirpc < Formula
       "--disable-silent-rules",
       "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <rpc/des_crypt.h>
+      #include <stdio.h>
+      int main () {
+        char key[] = "My8digitkey1234";
+        if (sizeof(key) != 16)
+          return 1;
+        des_setparity(key);
+        printf("%d\\n", sizeof(key));
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-I#{include}/tirpc", "-ltirpc", "-o", "test"
+    system "./test"
   end
 end

--- a/Formula/libtirpc.rb
+++ b/Formula/libtirpc.rb
@@ -1,6 +1,6 @@
 class Libtirpc < Formula
   desc "Port of Sun's Transport-Independent RPC library to Linux"
-  homepage "http://sourceforge.net/projects/libtirpc/"
+  homepage "https://sourceforge.net/projects/libtirpc/"
   url "https://downloads.sourceforge.net/project/libtirpc/libtirpc/1.0.3/libtirpc-1.0.3.tar.bz2"
   sha256 "86c3a78fc1bddefa96111dd233124c703b22a78884203c55c3e06b3be6a0fd5e"
   # tag "linuxbrew"

--- a/Formula/libtirpc.rb
+++ b/Formula/libtirpc.rb
@@ -2,7 +2,7 @@ class Libtirpc < Formula
   desc "Port of Sun's Transport-Independent RPC library to Linux"
   homepage "https://sourceforge.net/projects/libtirpc/"
   url "https://downloads.sourceforge.net/project/libtirpc/libtirpc/1.0.3/libtirpc-1.0.3.tar.bz2"
-  sha256 "86c3a78fc1bddefa96111dd233124c703b22a78884203c55c3e06b3be6a0fd5e"
+  sha256 "251a85b3bac687974f360d3796048c20ded3bf0bd69e0d1cfd1db23d013f89ed"
   # tag "linuxbrew"
 
   bottle do

--- a/Formula/libtirpc.rb
+++ b/Formula/libtirpc.rb
@@ -10,14 +10,14 @@ class Libtirpc < Formula
     sha256 "7c093d0948f7794df11cae0a0f0e974e8b0734d46beb2f7977db39d84aa16720" => :x86_64_linux # glibc 2.19
   end
 
-  depends_on "krb5"
+  depends_on "krb5" => :optional
 
   def install
     system "./configure",
-      "--disable-debug",
       "--disable-dependency-tracking",
       "--disable-silent-rules",
-      "--prefix=#{prefix}"
+      "--prefix=#{prefix}",
+      "#{"--disable-gssapi" if build.without? "krb5"}"
     system "make", "install"
   end
 

--- a/Formula/libtirpc.rb
+++ b/Formula/libtirpc.rb
@@ -17,7 +17,7 @@ class Libtirpc < Formula
       "--disable-dependency-tracking",
       "--disable-silent-rules",
       "--prefix=#{prefix}",
-      "#{"--disable-gssapi" if build.without? "krb5"}"
+      "--disable-gssapi" if build.without? "krb5"
     system "make", "install"
   end
 

--- a/Formula/libuuid.rb
+++ b/Formula/libuuid.rb
@@ -1,5 +1,5 @@
 class Libuuid < Formula
-  desc "Portable uuid C library"
+  desc "Portable UUID C library"
   homepage "https://sourceforge.net/projects/libuuid/"
   # tag "linuxbrew"
 

--- a/Formula/libuuid.rb
+++ b/Formula/libuuid.rb
@@ -4,7 +4,7 @@ class Libuuid < Formula
   # tag "linuxbrew"
 
   url "https://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz"
-  sha256 "251a85b3bac687974f360d3796048c20ded3bf0bd69e0d1cfd1db23d013f89ed"
+  sha256 "46af3275291091009ad7f1b899de3d0cea0252737550e7919d17237997db5644"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/libuuid.rb
+++ b/Formula/libuuid.rb
@@ -4,7 +4,7 @@ class Libuuid < Formula
   # tag "linuxbrew"
 
   url "https://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz"
-  sha256 "46af3275291091009ad7f1b899de3d0cea0252737550e7919d17237997db5644"
+  sha256 "251a85b3bac687974f360d3796048c20ded3bf0bd69e0d1cfd1db23d013f89ed"
 
   bottle do
     cellar :any_skip_relocation

--- a/Formula/libuuid.rb
+++ b/Formula/libuuid.rb
@@ -1,4 +1,5 @@
 class Libuuid < Formula
+  desc "Portable uuid C library"
   homepage "https://sourceforge.net/projects/libuuid/"
   # tag "linuxbrew"
 
@@ -20,5 +21,23 @@ class Libuuid < Formula
       "--disable-silent-rules",
       "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <uuid/uuid.h>
+      int main () {
+        uuid_t obj1, obj2, obj3, obj4;
+        uuid_generate(obj1);
+        uuid_generate_random(obj2);
+        uuid_generate_time(obj3);
+        if (uuid_generate_time_safe(obj4) != 0)
+            return 1;
+        return 0;
+      }
+    EOS
+
+    system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-luuid", "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
Fix several (not all) warnings produced by `brew audit --strict` for formulae that have "linuxbrew" tag.