### PR TITLE
whois: Fix test for Linux

### DIFF
--- a/Formula/whois.rb
+++ b/Formula/whois.rb
@@ -36,6 +36,6 @@ class Whois < Formula
   end
 
   test do
-    system "#{bin}/whois", "brew.sh"
+    system "#{bin}/whois", "brew.sh" if Pathname.new("/etc/services").readable?
   end
 end


### PR DESCRIPTION
Work around the error: `getaddrinfo(whois.nic.sh): Servname not supported for ai_socktype`
Install the package `netbase` to fix this error on Ubuntu.