### PR TITLE
davix: fix dependencies

### DIFF
--- a/Formula/davix.rb
+++ b/Formula/davix.rb
@@ -26,6 +26,9 @@ class Davix < Formula
   end
 
   def install
+    # Reduce memory usage below 4 GB for Circle CI.
+    ENV["MAKEFLAGS"] = "-j16" if ENV["CIRCLECI"]
+
     ENV.libcxx
 
     system "cmake", ".", *std_cmake_args

--- a/Formula/davix.rb
+++ b/Formula/davix.rb
@@ -18,7 +18,12 @@ class Davix < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "openssl"
-  depends_on "ossp-uuid"
+  if OS.mac?
+    depends_on "ossp-uuid"
+  else
+    depends_on "libxml2"
+    depends_on "util-linux" # for libuuid
+  end
 
   def install
     ENV.libcxx


### PR DESCRIPTION
This patch fixes build errors that I encountered when I did `brew install davix` on CentOS 6.10 w/o sudo:
```
/tmp/davix-20180824-31990-1tlk76h/deps/libneon/src/ne_utils.c:47:31: fatal error: libxml/xmlversion.h: No such file or directory
/tmp/davix-20180824-31990-1tlk76h/deps/libneon/src/ne_xml.c:60:31: fatal error: libxml/xmlversion.h: No such file or directory
```
and
```
/tmp/davix-20180824-17284-1p08r3g/src/fileops/AzureIO.cpp:23:23: fatal error: uuid/uuid.h: No such file or directory
```
-----
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?