### PR TITLE
boost-python: Fix test [Linux]

### DIFF
--- a/Formula/boost-python.rb
+++ b/Formula/boost-python.rb
@@ -66,7 +66,7 @@ class BoostPython < Formula
     pyincludes = Utils.popen_read("python-config --includes").chomp.split(" ")
     pylib = Utils.popen_read("python-config --ldflags").chomp.split(" ")
 
-    system ENV.cxx, "-shared", "hello.cpp", "-L#{lib}", "-lboost_python27", "-o",
+    system ENV.cxx, "-shared", "-fPIC", "hello.cpp", "-L#{lib}", "-lboost_python27", "-o",
            "hello.so", *pyincludes, *pylib
 
     output = <<~EOS


### PR DESCRIPTION
Fix error:
```
ld: /tmp/ccIOdshX.o: relocation R_X86_64_32 against `.rodata'
can not be used when making a shared object; recompile with -fPIC
```