### PR TITLE
gdcm: Rebuild bottle with Python 2 [Linux]

### DIFF
--- a/Formula/gdcm.rb
+++ b/Formula/gdcm.rb
@@ -3,12 +3,12 @@ class Gdcm < Formula
   homepage "https://sourceforge.net/projects/gdcm/"
   url "https://downloads.sourceforge.net/project/gdcm/gdcm%202.x/GDCM%202.8.7/gdcm-2.8.7.tar.gz"
   sha256 "7a08baa93e90bce17d9999d59b95876808801a287812348e27a23decb1ebc58c"
+  revision 1 unless OS.mac?
 
   bottle do
     sha256 "ad87ce2f85f16278131b692b12c33cbf1f02af7263c04a9b3dc1cb8188bcdf53" => :high_sierra
     sha256 "ba985660d7000a4f8b054a63269c60cab9c542e46e81864d8ef8621c2a246cbf" => :sierra
     sha256 "66d1542a14b6c6e75946853944662d4a934101ceb9c865a9c1da527884133bd6" => :el_capitan
-    sha256 "95bec7680822e43e352a9b92b5fd7ae221b7c91e9f692acbbc6ecf4d62562664" => :x86_64_linux
   end
 
   option "without-python@2", "Build without python2 support"
@@ -24,8 +24,6 @@ class Gdcm < Formula
   depends_on "pkg-config" => :build
   depends_on "openjpeg"
   depends_on "openssl"
-
-  depends_on "python" => :recommended unless OS.mac?
 
   needs :cxx11
 


### PR DESCRIPTION
Fix the error:
```
ModuleNotFoundError: No module named 'gdcm'
```