### PR TITLE
llvm@4: Fix test for Linux

### DIFF
--- a/Formula/llvm@4.rb
+++ b/Formula/llvm@4.rb
@@ -328,6 +328,7 @@ class LlvmAT4 < Formula
 
     system "#{bin}/clang", "-L#{lib}", "-fopenmp", "-nobuiltininc",
                            "-I#{lib}/clang/#{version}/include",
+                           *("-Wl,-rpath=#{lib}" unless OS.mac?),
                            "omptest.c", "-o", "omptest"
     testresult = shell_output("./omptest")
 
@@ -361,7 +362,7 @@ class LlvmAT4 < Formula
     EOS
 
     # Testing Command Line Tools
-    if MacOS::CLT.installed?
+    if OS.mac? && MacOS::CLT.installed?
       libclangclt = Dir["/Library/Developer/CommandLineTools/usr/lib/clang/#{MacOS::CLT.version.to_i}*"].last { |f| File.directory? f }
 
       system "#{bin}/clang++", "-v", "-nostdinc",
@@ -379,7 +380,7 @@ class LlvmAT4 < Formula
     end
 
     # Testing Xcode
-    if MacOS::Xcode.installed?
+    if OS.mac? && MacOS::Xcode.installed?
       libclangxc = Dir["#{MacOS::Xcode.toolchain_path}/usr/lib/clang/#{DevelopmentTools.clang_version}*"].last { |f| File.directory? f }
 
       system "#{bin}/clang++", "-v", "-nostdinc",


### PR DESCRIPTION
Fix  the error:
```
./omptest: error while loading shared libraries: libomp.so:
cannot open shared object file: No such file or directory
```