### PR TITLE
mycli: Rebuild bottle for Linux

### DIFF
--- a/Formula/mycli.rb
+++ b/Formula/mycli.rb
@@ -5,13 +5,13 @@ class Mycli < Formula
   homepage "https://mycli.net/"
   url "https://files.pythonhosted.org/packages/de/19/74c21a13074d13d955e2ad16943b0f12b0bf78845dc130f2d46f451b65cc/mycli-1.16.0.tar.gz"
   sha256 "29c65537b6616619b45956550fa76662caa6631eeee96e5cafd407909d8e9649"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any
     sha256 "0e595019db782a382f315a1c449334391b17630194193b45c61bfdd4e20efeb2" => :high_sierra
     sha256 "a1d590e59cd55c5539032bbb6e3682de3ac687c924418a57875fdac7cc7042c1" => :sierra
     sha256 "efb1798af243e65cc470d754439b5d82fde609081d5e77b40e0a29ea0d36b5d1" => :el_capitan
-    sha256 "620e535375e4574f4b6d8ee5223b36e2a3f7d73be8299c2e3b1b065a50e00efc" => :x86_64_linux
   end
 
   depends_on "python@2"


### PR DESCRIPTION
Fix the error:
```
pkg_resources.DistributionNotFound: The 'mycli==1.16.0' distribution
was not found and is required by the application
```