### PR TITLE
charm-tools: Rebuild bottle for Linux

### DIFF
--- a/Formula/charm-tools.rb
+++ b/Formula/charm-tools.rb
@@ -5,14 +5,13 @@ class CharmTools < Formula
   homepage "https://github.com/juju/charm-tools"
   url "https://files.pythonhosted.org/packages/99/4d/16d7398fe5eefc602a8870fb3e93597aabe681b0f1497749148695cba4a1/charm-tools-2.2.3.tar.gz"
   sha256 "ea659f59041cb3dff0be862d657830591e656a9a259931064edab7477875245b"
-  revision 3
+  revision OS.mac? ? 3 : 4
 
   bottle do
     cellar :any
     sha256 "68365eeb6730d2d7645a791c7d60206d733f19d56c16deb31e5b42cc0378bc28" => :high_sierra
     sha256 "4dc6ab436414c0ffd0c07601bec4240b2907c090b7a7a300c5ec6bc49e960a01" => :sierra
     sha256 "11a6747479a401661fcd32e6233e581ec0f065a0fc737ee3da163c23d73bb00d" => :el_capitan
-    sha256 "76c99fde238ddfeaae2116243ada8187398c3466d400676c85bb4a1e0a801b87" => :x86_64_linux
   end
 
   depends_on "python@2"


### PR DESCRIPTION
Fix the test error:
```
pkg_resources.DistributionNotFound: The 'charm-tools==2.2.3'
distribution was not found and is required by the application
```