### PR TITLE
nanopb-generator: Fix the python interpreter [Linux]

### DIFF
--- a/Formula/nanopb-generator.rb
+++ b/Formula/nanopb-generator.rb
@@ -3,13 +3,13 @@ class NanopbGenerator < Formula
   homepage "https://jpa.kapsi.fi/nanopb/docs/index.html"
   url "https://jpa.kapsi.fi/nanopb/download/nanopb-0.3.9.1.tar.gz"
   sha256 "e677290fdb419a3d437b824ef9eac02b8d1672fb30d60dd1f3113eae405b1f5b"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any_skip_relocation
     sha256 "298fbe96efa71f53a4bfb7ae92d0e1cf31b8d9749611300ecc02dcefe20be9d8" => :high_sierra
     sha256 "298fbe96efa71f53a4bfb7ae92d0e1cf31b8d9749611300ecc02dcefe20be9d8" => :sierra
     sha256 "298fbe96efa71f53a4bfb7ae92d0e1cf31b8d9749611300ecc02dcefe20be9d8" => :el_capitan
-    sha256 "a1d7a5a249a8b3736a109311b94dea672ec0696106a3d3aae9d7a4b13e8bea06" => :x86_64_linux
   end
 
   depends_on "python@2"
@@ -22,7 +22,7 @@ class NanopbGenerator < Formula
     cd "generator" do
       system "make", "-C", "proto"
       inreplace "nanopb_generator.py", %r{^#!/usr/bin/env python$},
-                                       "#!/usr/bin/python"
+                                       "#!/usr/bin/python" if OS.mac?
       libexec.install "nanopb_generator.py", "protoc-gen-nanopb", "proto"
       bin.install_symlink libexec/"protoc-gen-nanopb", libexec/"nanopb_generator.py"
     end


### PR DESCRIPTION
Fix the error:
```
exec: /home/linuxbrew/.linuxbrew/Cellar/nanopb-generator/0.3.9.1/bin/nanopb_generator.py: not found
```