### PR TITLE
libewf: fixes for Linuxbrew

### DIFF
--- a/Formula/libewf.rb
+++ b/Formula/libewf.rb
@@ -35,7 +35,6 @@ class Libewf < Formula
   else
     depends_on "bzip2"
     depends_on "libfuse" => :optional
-    depends_on "util-linux" => :optional
     depends_on "zlib"
   end
 
@@ -56,7 +55,6 @@ class Libewf < Formula
     ]
 
     args << "--with-libfuse=no" if build.without?(OS.mac? ? "osxfuse" : "libfuse")
-    args << "--with-libuuid=#{build.with?("util-linux") ? Formula["util-linux"].opt_prefix.to_s : "no"}" unless OS.mac?
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/libewf.rb
+++ b/Formula/libewf.rb
@@ -30,9 +30,18 @@ class Libewf < Formula
 
   depends_on "pkg-config" => :build
   depends_on "openssl"
-  depends_on :osxfuse => :optional
+  if OS.mac?
+    depends_on :osxfuse => :optional
+  else
+    depends_on "libfuse" => :optional
+    depends_on "libuuid"
+    depends_on "zlib"
+    depends_on "bzip2"
+  end
 
   def install
+    ENV.append_to_cflags "-std=gnu89" if ENV.cc == "gcc-5"
+
     if build.head?
       system "./synclibs.sh"
       system "./autogen.sh"
@@ -44,7 +53,7 @@ class Libewf < Formula
       --prefix=#{prefix}
     ]
 
-    args << "--with-libfuse=no" if build.without? "osxfuse"
+    args << "--with-libfuse=no" if build.without?(OS.mac? ? "osxfuse" : "libfuse")
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/libewf.rb
+++ b/Formula/libewf.rb
@@ -33,13 +33,15 @@ class Libewf < Formula
   if OS.mac?
     depends_on :osxfuse => :optional
   else
-    depends_on "libfuse" => :optional
-    depends_on "libuuid"
-    depends_on "zlib"
     depends_on "bzip2"
+    depends_on "libfuse" => :optional
+    depends_on "util-linux" => :optional
+    depends_on "zlib"
   end
 
   def install
+    # Workaround bug in gcc-5 that causes the following error:
+    # undefined reference to `libuna_ ...
     ENV.append_to_cflags "-std=gnu89" if ENV.cc == "gcc-5"
 
     if build.head?
@@ -54,6 +56,7 @@ class Libewf < Formula
     ]
 
     args << "--with-libfuse=no" if build.without?(OS.mac? ? "osxfuse" : "libfuse")
+    args << "--with-libuuid=#{build.with?("util-linux") ? Formula["util-linux"].opt_prefix.to_s : "no"}" unless OS.mac?
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
Fixes for `libewf` formula for Linuxbrew.

1. optionally depend on `libfuse` on Linux
2. depend on libuuid - Mac has native uuid support, so to make bottle comparable I've added a dependency on `libuuid`. Formula works without this dependency, so this can be discussed.
3. Failure (see Linuxbrew/homebrew-core#8866) is caused by a bug in `gcc-5`, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=777938
Unfortunately, applying the patch from the link above does not help. So, we have to enable `-std=gnu89` flag globally.

