### PR TITLE
libtirpc: fix audit warnings, add test block

### DIFF
--- a/Formula/libtirpc.rb
+++ b/Formula/libtirpc.rb
@@ -1,23 +1,40 @@
 class Libtirpc < Formula
   desc "Port of Sun's Transport-Independent RPC library to Linux"
-  homepage "http://sourceforge.net/projects/libtirpc/"
+  homepage "https://sourceforge.net/projects/libtirpc/"
   url "https://downloads.sourceforge.net/project/libtirpc/libtirpc/1.0.1/libtirpc-1.0.1.tar.bz2"
   sha256 "5156974f31be7ccbc8ab1de37c4739af6d9d42c87b1d5caf4835dda75fcbb89e"
+  revision 1
   # tag "linuxbrew"
 
   bottle do
     cellar :any_skip_relocation
-    sha256 "7c093d0948f7794df11cae0a0f0e974e8b0734d46beb2f7977db39d84aa16720" => :x86_64_linux # glibc 2.19
   end
 
   depends_on "krb5" => :optional unless OS.mac?
 
   def install
     system "./configure",
-      "--disable-debug",
       "--disable-dependency-tracking",
       "--disable-silent-rules",
-      "--prefix=#{prefix}"
+      "--prefix=#{prefix}",
+      *("--disable-gssapi" if build.without? "krb5")
     system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <rpc/des_crypt.h>
+      #include <stdio.h>
+      int main () {
+        char key[] = "My8digitkey1234";
+        if (sizeof(key) != 16)
+          return 1;
+        des_setparity(key);
+        printf("%d\\n", sizeof(key));
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-I#{include}/tirpc", "-ltirpc", "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
[WIP]

I'll break this PR into two later.
Question: why does it have `unless OS.mac?` if this is a Linuxbrew-only formula?