### PR TITLE
libjson-rpc-cpp: add missing dependency [Linux]

### DIFF
--- a/Formula/libjson-rpc-cpp.rb
+++ b/Formula/libjson-rpc-cpp.rb
@@ -19,6 +19,7 @@ class LibjsonRpcCpp < Formula
   depends_on "jsoncpp"
   depends_on "libmicrohttpd"
   depends_on "hiredis"
+  depends_on "curl" unless OS.mac?
 
   def install
     system "cmake", ".", *std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
