### PR TITLE
texinfo: Fix build error related to perl dependency

### DIFF
--- a/Formula/texinfo.rb
+++ b/Formula/texinfo.rb
@@ -23,6 +23,7 @@ class Texinfo < Formula
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-install-warnings",
+                          *("--disable-perl-xs" unless OS.mac?),
                           "--prefix=#{prefix}"
     system "make", "install"
     doc.install Dir["doc/refcard/txirefcard*"]


### PR DESCRIPTION
Fixes #8597.

Build log: https://gist.github.com/aaa46b6961c190f9a935fbd5244d9cff


- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----