### PR TITLE
valabind: Add patch to fix missing rpath

### DIFF
--- a/Formula/valabind.rb
+++ b/Formula/valabind.rb
@@ -3,7 +3,7 @@ class Valabind < Formula
   homepage "https://radare.org/"
   url "https://github.com/radare/valabind/archive/1.6.0.tar.gz"
   sha256 "0d266486655c257fd993758c3e4cc8e32f0ec6f45d0c0e15bb6e6be986e4b78e"
-  revision 1
+  revision OS.mac? ? 1 : 2
   head "https://github.com/radare/valabind.git"
 
   bottle do
@@ -12,6 +12,12 @@ class Valabind < Formula
     sha256 "9cc2312ef64b8f1d39a36d9b157d9112920ebdda221e64d0680b32e641e0a795" => :high_sierra
     sha256 "e9ffa47579200c0f8a1394c6495b1c8c52d581084bcd9273121d4e907fff307c" => :sierra
     sha256 "c43502d503c09c23f2c225250c5e8ccf9f7100b88703767f27ceed729b55a8c3" => :el_capitan
+  end
+
+  patch do
+    # Please remove this patch for valabind > 1.6.0.
+    url "https://github.com/radare/valabind/commit/774707925962fe5865002587ef031048acbe9d89.patch?full_index=1"
+    sha256 "d6a88a7c98ab0e001c4ce2d50e809ed4c4b9258954133434758d1f0c5e26f9e9"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Adds an upstream patch that fixes the `rpath` of valabind so that it is able to locate vala's code generator.

Without this fix `radare2` fails to build:
```
valabind --swig -I /home/eholmda/.linuxbrew/Cellar/radare2/2.8.0/include/libr -x -N SDB -N Radare --vapidir ../vapi -o r_asm.i -m r_asm ../vapi/r_asm --swig                                                                                                                                                                  
valabind: error while loading shared libraries: libvalaccodegen.so: cannot open shared object file: No such file or directory                                                                                                                                                                                                 
make: *** [../rules.mk:34: r_asm.so] Error 1                                                                                                                                                                    
valabind --swig -I /home/eholmda/.linuxbrew/Cellar/radare2/2.8.0/include/libr -I /home/eholmda/.linuxbrew/Cellar/openssl/1.0.2p/include -I /home/eholmda/.linuxbrew/Cellar/radare2/2.8.0/include/libr -x -N SDB -N Radare --vapidir ../vapi -o r_core.i -m r_core ../vapi/r_core --swig                                       
valabind: error while loading shared libraries: libvalaccodegen.so: cannot open shared object file: No such file or directory   
```