### PR TITLE
radare2: Depends on perl

### DIFF
--- a/Formula/radare2.rb
+++ b/Formula/radare2.rb
@@ -68,6 +68,7 @@ class Radare2 < Formula
   depends_on "lua"
   depends_on "openssl"
   depends_on "yara"
+  depends_on "perl" unless OS.mac?
 
   def install
     # Build Radare2 before bindings, otherwise compile = nope.


### PR DESCRIPTION
The language bindings for radare2 require perl to be installed.

```
g++-5 -fPIC -shared r_core_wrap.cxx -DG_BEGIN_DECLS -DG_END_DECLS -DG_GNUC_CONST -DSWIG_PYTHON_SILENT_MEMLEAK -D_REENTRANT -D_GNU_SOURCE -pipe -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -I/usr/lib64/perl5/CORE -I/home/eholmda/.linuxbrew/Cellar/radare2/2.8.0/include/libr -I/home/eholmda/.linuxbrew
/Cellar/openssl/1.0.2p/include -I/home/eholmda/.linuxbrew/Cellar/radare2/2.8.0/include/libr -o r_core.so -ldl -lr_util -lr_hash -lr_crypto -lr_magic -lr_socket -lr_io -lr_fs -lr_syscall -lr_search -lr_reg -lr_cons -lr_flag -lr_parse -lr_lang -lr_asm -lr_egg -lr_bp -lr_anal -lr_bin -lr_debug -lr_config -lcrypto -lssl 
-lr_core -L/home/eholmda/.linuxbrew/Cellar/radare2/2.8.0/lib -L/home/eholmda/.linuxbrew/Cellar/openssl/1.0.2p/lib -L/home/eholmda/.linuxbrew/Cellar/radare2/2.8.0/lib -Wl,--enable-new-dtags -Wl,-rpath,/usr/lib64/perl5/CORE -fstack-protector -L/usr/lib64/perl5/CORE -lperl -lresolv -lnsl -ldl -lm -lcrypt -lutil -lpthrea
d -lc                                                                                                                                                                                                                                                                                                                         
r_core_wrap.cxx:762:20: fatal error: EXTERN.h: No such file or directory                                                                                                                                                                                                                                                      
compilation terminated.                                                                                                                                                                                                                                                                                                       
make: *** [../rules.mk:34: r_core.so] Error 1     
```