### PR TITLE
CircleCI: Set HOMEBREW_MAKE_JOBS=8 [Linux]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       HOMEBREW_VERBOSE: 1
       HOMEBREW_VERBOSE_USING_DOTS: 1
       HOMEBREW_FAIL_LOG_LINES: 300
+      HOMEBREW_MAKE_JOBS: 8
     steps:
       - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends netbase
       - run: |


### PR DESCRIPTION
Reduce the number of default number of make jobs to 8.

The default number of HOMEBREW_MAKE_JOBS on CircleCI for Linux is 32.
The resources available reported by CircleCI are 2 CPU and 4 GB RAM.
32 processes of GCC often exceeds the 4 GB of available memory.
Since our instance has only 2 CPU, it's likely not any faster either.