### PR TITLE
gettext: point build to libxml2 resource

### DIFF
--- a/Formula/gettext.rb
+++ b/Formula/gettext.rb
@@ -59,6 +59,7 @@ class Gettext < Formula
                           "--without-git",
                           "--without-cvs",
                           "--without-xz",
+                          ("--with-libxml2-prefix=#{libexec}" unless OS.mac?),
                           ("--with-libxml2-prefix=#{Formula["libxml2"].opt_prefix}" if OS.mac?)
     system "make"
     ENV.deparallelize # install doesn't support multiple make jobs


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This provides the requested fix for the gettext/libxml2 issue reported in #9272 

The gist showing the build failure in that report is here: https://gist.github.com/drbenmorgan/01baa12d439ebd13e3e7f00025783da1