### PR TITLE
fontconfig: fix #9270

### DIFF
--- a/Formula/fontconfig.rb
+++ b/Formula/fontconfig.rb
@@ -40,6 +40,7 @@ class Fontconfig < Formula
     depends_on "gperf" => :build
     depends_on "gettext" => :build
     depends_on "libtool" => :build
+    depends_on "json-c" => :build
     depends_on "bzip2"
     depends_on "expat"
     depends_on "util-linux" # for libuuid


### PR DESCRIPTION
Close #9270
fontconfig 2.13.1 requires an additional build-time dependency on "json-c"

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Could you correct my commit if there are any problems?
