### PR TITLE
wxmac: Depends on linuxbrew/xorg/libsm [Linux]

### DIFF
--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -30,6 +30,7 @@ class Wxmac < Formula
   unless OS.mac?
     depends_on "gtk+"
     depends_on "linuxbrew/xorg/glu"
+    depends_on "linuxbrew/xorg/libsm"
   end
 
   def install

--- a/Formula/wxmac.rb
+++ b/Formula/wxmac.rb
@@ -28,6 +28,7 @@ class Wxmac < Formula
   depends_on "libtiff"
 
   unless OS.mac?
+    depends_on "pkg-config" => :build
     depends_on "gtk+"
     depends_on "linuxbrew/xorg/glu"
     depends_on "linuxbrew/xorg/libsm"


### PR DESCRIPTION
```
$ brew linkage wxmac
Undeclared dependencies with linkage:
  linuxbrew/xorg/libsm
$ brew linkage --reverse wxmac
/home/linuxbrew/.linuxbrew/lib/libSM.so.6
  lib/libwx_gtk2u_adv-3.0.so.0.4.0
...
```