### PR TITLE
magic-wormhole: Fix Error: Will not overwrite [Linux]

### DIFF
--- a/Formula/magic-wormhole.rb
+++ b/Formula/magic-wormhole.rb
@@ -163,7 +163,13 @@ class MagicWormhole < Formula
     ENV["SODIUM_INSTALL"] = "system"
     venv = virtualenv_create(libexec, "python3")
     venv.pip_install resource("cffi")
-    virtualenv_install_with_resources
+    if OS.mac?
+      virtualenv_install_with_resources
+    else
+      # Fix Error: Will not overwrite /home/linuxbrew/.linuxbrew/Cellar/magic-wormhole/0.10.5_4/libexec/lib/python3.7/site-packages/homebrew_deps.pth
+      venv.pip_install resources
+      venv.pip_install_and_link buildpath
+    end
   end
 
   test do


### PR DESCRIPTION
Fix `Error: Will not overwrite /home/linuxbrew/.linuxbrew/Cellar/magic-wormhole/0.10.5_4/libexec/lib/python3.7/site-packages/homebrew_deps.pth`