### PR TITLE
Add vagrant 2.1.5

### DIFF
--- a/Formula/vagrant.rb
+++ b/Formula/vagrant.rb
@@ -1,0 +1,11 @@
+class Vagrant < Formula
+  desc "Command line utility for managing the lifecycle of virtual machines"
+  homepage "https://www.vagrantup.com/"
+  url "https://releases.hashicorp.com/vagrant/2.1.5/vagrant_2.1.5_linux_amd64.zip"
+  sha256 "42e83e075d70045214f72448f514bef969b9a107a63eef7f39fc31e4e75dd10a"
+  version "2.1.5"
+
+  def install
+    bin.install "vagrant"
+  end
+end

--- a/Formula/vagrant.rb
+++ b/Formula/vagrant.rb
@@ -1,9 +1,9 @@
 class Vagrant < Formula
-  desc "Command line utility for managing the lifecycle of virtual machines"
+  desc "Command-line utility for managing the lifecycle of virtual machines"
   homepage "https://www.vagrantup.com/"
   url "https://releases.hashicorp.com/vagrant/2.1.5/vagrant_2.1.5_linux_amd64.zip"
-  sha256 "42e83e075d70045214f72448f514bef969b9a107a63eef7f39fc31e4e75dd10a"
   version "2.1.5"
+  sha256 "42e83e075d70045214f72448f514bef969b9a107a63eef7f39fc31e4e75dd10a"
 
   def install
     bin.install "vagrant"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? **Does not pass. fails with `FormulaAuditStrict/Test: A `test do` test block should be added`**

-----

Formula for vagrant.

Help needed: 
- obviously, this is amd64 plaf only, how to restrict this formula for that plaf? (or is unneeded as linuxbrew is also just x64?)
- CI yells about test: vagrant alone may do only `vagrant version`, that OTOH is considered a "bad tests". How else to test vagrant install? IMO, test is unneded as this is vendor provided "bottle"?