### PR TITLE
abyss: gcc is a dependency on macOS only

### DIFF
--- a/Formula/abyss.rb
+++ b/Formula/abyss.rb
@@ -22,7 +22,7 @@ class Abyss < Formula
 
   depends_on "boost" => :build
   depends_on "google-sparsehash" => :build
-  depends_on "gcc"
+  depends_on "gcc" if OS.mac?
   depends_on "open-mpi"
 
   fails_with :clang # no OpenMP support


### PR DESCRIPTION
This PR may be squash-merged.