### PR TITLE
squashfs: Fix for newer gcc and Linux

### DIFF
--- a/Formula/squashfs.rb
+++ b/Formula/squashfs.rb
@@ -16,6 +16,7 @@ class Squashfs < Formula
   depends_on "lzo"
   depends_on "xz"
   depends_on "lz4" => :optional
+  depends_on "zlib" unless OS.mac?
 
   # Patch necessary to emulate the sigtimedwait process otherwise we get build failures
   # Also clang fixes, extra endianness knowledge and a bundle of other macOS fixes.
@@ -23,6 +24,13 @@ class Squashfs < Formula
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/05ae0eb1/squashfs/squashfs-osx-bundle.diff"
     sha256 "276763d01ec675793ddb0ae293fbe82cbf96235ade0258d767b6a225a84bc75f"
+  end
+
+  # Fixes the following compilation issue of squash4.3 with newer versions of gcc:
+  # "mksquashfs.c:987:24: error: called object 'major' is not a function or function pointer"
+  patch do
+    url "https://raw.githubusercontent.com/rchikhi/formula-patches/14e9deef14117908e24c17b81b60b11996688991/squashfs/squashfs-new-gcc.diff"
+    sha256 "24e51ef16f6e6101b59f4913aa4acbd6ff541a1953e923019e8648f6e6bdd582"
   end
 
   def install


### PR DESCRIPTION
- [ to some extend; see below] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [see below] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [I do not want to create new gists on my Github account] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

This PR fixes compilation of squashfs on recent linux systems.


Output of `brew test` fails on my arch system:

```
$ brew test squashfs
Error: cannot load such file -- test/unit/assertions

```

Output of `brew audit` fails too

```
$ brew audit squashfs.rb
==> Installing or updating 'rubocop' gem
Building native extensions. This could take a while...
ERROR:  Error installing rubocop:
        ERROR: Failed to build gem native extension.

    current directory: 
/home/rayan/.linuxbrew/Library/Homebrew/vendor/bundle/ruby/2.5.0/gems/jaro_winkler-1.5.1/ext/jaro_winkler
/usr/bin/ruby -r ./siteconf20181013-1836-1tsnq2x.rb extconf.rb
creating Makefile
[..]
make "DESTDIR="
compiling adj_matrix.c
compiling codepoints.c
compiling jaro.c
compiling jaro_winkler.c
In file included from adj_matrix.c:2:
codepoints.h:2:10: fatal error: ruby.h: No such file or directory
 #include "ruby.h"
          ^~~~~~~~
compilation terminated.

```