### PR TITLE
libxkbcommon: do not depend on xorg [Linux]

### DIFF
--- a/Formula/libxkbcommon.rb
+++ b/Formula/libxkbcommon.rb
@@ -27,7 +27,6 @@ class Libxkbcommon < Formula
 
   unless OS.mac?
     depends_on "linuxbrew/xorg/xkeyboardconfig"
-    depends_on "linuxbrew/xorg/xorg"
     depends_on "linuxbrew/xorg/libxcb"
   end
 


### PR DESCRIPTION
🖖 