### PR TITLE
libxslt: Specify Python.h path to python@2 installation

### DIFF
--- a/Formula/libxslt.rb
+++ b/Formula/libxslt.rb
@@ -27,7 +27,7 @@ class Libxslt < Formula
   keg_only :provided_by_macos
 
   depends_on "libxml2"
-  depends_on "python@2"
+  depends_on "python@2" unless OS.mac?
 
   def install
     if build.head?
@@ -42,7 +42,7 @@ class Libxslt < Formula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
                           ("--without-crypto" if OS.linux?),
-                          "--with-python=#{Formula["python@2"].opt_include}",
+                          ("--with-python=#{Formula["python@2"].opt_include}" unless OS.mac?),
                           "--with-libxml-prefix=#{Formula["libxml2"].opt_prefix}"
     system "make"
     system "make", "install"

--- a/Formula/libxslt.rb
+++ b/Formula/libxslt.rb
@@ -42,7 +42,7 @@ class Libxslt < Formula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
                           ("--without-crypto" if OS.linux?),
-                          "--with-python=#{Formula["python@2"].opt_include}"
+                          "--with-python=#{Formula["python@2"].opt_include}",
                           "--with-libxml-prefix=#{Formula["libxml2"].opt_prefix}"
     system "make"
     system "make", "install"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
This commit is attempting to fix issue #9443 .

During config of libxslt, on some linux systems it cannot find the system's python header files, leading to failure in installation.

This commit points to python@2 installation managed by linuxbrew so the config script can find the header file. Python@2 is added as a dependency for the formula as well.