### PR TITLE
zpython: Depends on python@2

### DIFF
--- a/Formula/zpython.rb
+++ b/Formula/zpython.rb
@@ -34,6 +34,7 @@ class Zpython < Formula
   end
 
   depends_on "autoconf" => :build
+  depends_on "python@2" unless OS.mac?
   depends_on "zsh"
 
   def install


### PR DESCRIPTION
The package will fail to build without Python 2:

```
==> make
Last 15 lines from /home/eholmda/.cache/Homebrew/Logs/zpython/03.make:
gcc-5  -s -shared -o zprof.bundle   zprof..o    -lnsl -ldl -lncursesw -lrt -lm  -lc  -L/usr/lib64/python2.7/config -lpython2.7 -lpthread -ldl -lutil -lm -Xlinker -export-dynamic
gcc-5 -c -I. -I../../Src -I../../Src -I../../Src/Zle -I.  -DHAVE_CONFIG_H -DMODULE -Wall -Wmissing-prototypes -O2 -I/usr/include/python2.7 -DPYTHON_HOME=\"/usr\" -pthread -fPIC -o zpty..o zpty.c                                                                                                                           
( echo '#!'; cat zpty.syms  | sed -n '/^X/{s/^X//;p;}' | sort -u ) > zpty.export
rm -f zpty.bundle
gcc-5  -s -shared -o zpty.bundle   zpty..o    -lnsl -ldl -lncursesw -lrt -lm  -lc  -L/usr/lib64/python2.7/config -lpython2.7 -lpthread -ldl -lutil -lm -Xlinker -export-dynamic
gcc-5 -c -I. -I../../Src -I../../Src -I../../Src/Zle -I.  -DHAVE_CONFIG_H -DMODULE -Wall -Wmissing-prototypes -O2 -I/usr/include/python2.7 -DPYTHON_HOME=\"/usr\" -pthread -fPIC -o zpython..o zpython.c
zpython.c:3:20: fatal error: Python.h: No such file or directory
compilation terminated.
make[3]: *** [Makefile:241: zpython..o] Error 1
make[3]: Leaving directory '/tmp/zpython-20181015-410656-1myvn10/zsh-5.0.5/Src/Modules'
make[2]: *** [Makemod:373: modules] Error 1
make[2]: Leaving directory '/tmp/zpython-20181015-410656-1myvn10/zsh-5.0.5/Src'
make[1]: *** [Makefile:451: modules] Error 2
make[1]: Leaving directory '/tmp/zpython-20181015-410656-1myvn10/zsh-5.0.5/Src'
make: *** [Makefile:189: all] Error 1
```