### PR TITLE
hwloc: Disable cairo explicitly

### DIFF
--- a/Formula/hwloc.rb
+++ b/Formula/hwloc.rb
@@ -24,13 +24,18 @@ class Hwloc < Formula
   depends_on "cairo" => :optional
 
   def install
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --enable-shared
+      --enable-static
+      --prefix=#{prefix}
+      --without-x
+    ]
+    args << "--disable-cairo" if build.without? "cairo"
+
     system "./autogen.sh" if build.head?
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--enable-shared",
-                          "--enable-static",
-                          "--prefix=#{prefix}",
-                          "--without-x"
+    system "./configure", *args
     system "make", "install"
 
     pkgshare.install "tests"


### PR DESCRIPTION
Unless cairo is explicitly disabled during configure hwloc will attempt to use it:

```
==> make install
Last 15 lines from /home/eholmda/.cache/Homebrew/Logs/hwloc/02.make:
Creating lstopo-no-graphics.1 man page...
  CC       lstopo-lstopo-text.o
  CC       lstopo-lstopo-xml.o
  CC       lstopo-lstopo-cairo.o
lstopo-cairo.c:11:19: fatal error: cairo.h: No such file or directory                                                                                                                                                                                                                                                        
compilation terminated.
make[2]: *** [Makefile:975: lstopo-lstopo-cairo.o] Error 1
make[2]: *** Waiting for unfinished jobs....
lstopo.c:30:19: fatal error: cairo.h: No such file or directory
compilation terminated.
make[2]: *** [Makefile:877: lstopo-lstopo.o] Error 1
make[2]: Leaving directory '/tmp/hwloc-20181015-237104-1uzkbwx/hwloc-2.0.2/utils/lstopo'
make[1]: *** [Makefile:454: install-recursive] Error 1
make[1]: Leaving directory '/tmp/hwloc-20181015-237104-1uzkbwx/hwloc-2.0.2/utils'
make: *** [Makefile:629: install-recursive] Error 1
```