### PR TITLE
flann: fix build for Linuxbrew (retry #7275)

### DIFF
--- a/Formula/flann.rb
+++ b/Formula/flann.rb
@@ -19,6 +19,11 @@ class Flann < Formula
   depends_on "python@2" => :optional
   depends_on "numpy" if build.with? "python@2"
 
+  patch do
+    url "https://raw.githubusercontent.com/buildroot/buildroot/0c469478f64d0ddaf72c0622a1830d855306d51c/package/flann/0001-src-cpp-fix-cmake-3.11-build.patch"
+    sha256 "aa181d0731d4e9a266f7fcaf5423e7a6b783f400cc040a3ef0fef77930ecf680"
+  end unless OS.mac?
+
   resource("dataset.dat") do
     url "https://www.cs.ubc.ca/research/flann/uploads/FLANN/datasets/dataset.dat"
     sha256 "dcbf0268a7ff9acd7c3972623e9da722a8788f5e474ae478b888c255ff73d981"

--- a/Formula/flann.rb
+++ b/Formula/flann.rb
@@ -19,6 +19,8 @@ class Flann < Formula
   depends_on "python@2" => :optional
   depends_on "numpy" if build.with? "python@2"
 
+  # Fix for Linux build: https://bugs.gentoo.org/652594
+  # Not yet fixed upstream: https://github.com/mariusmuja/flann/issues/369
   patch do
     url "https://raw.githubusercontent.com/buildroot/buildroot/0c469478f64d0ddaf72c0622a1830d855306d51c/package/flann/0001-src-cpp-fix-cmake-3.11-build.patch"
     sha256 "aa181d0731d4e9a266f7fcaf5423e7a6b783f400cc040a3ef0fef77930ecf680"


### PR DESCRIPTION
2nd try for #7275 that applies patch from https://bugs.gentoo.org/652594

- [X] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

~~~
$ brew install flann
==> Downloading https://github.com/mariusmuja/flann/archive/1.9.1.tar.gz
Already downloaded: /home/linuxbrew/.cache/Homebrew/downloads/0be5f8a6ab80842215d1fe929bec1f9227967fa542b3e8cc47c0e47f1f3eb1fc--flann-1.9.1.tar.gz
==> cmake . -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG -DCMAKE_INSTALL_PREFIX=/home/linuxbrew/.linuxbrew/Cellar/
Last 15 lines from /home/linuxbrew/Library/Logs/Homebrew/flann/01.cmake:
-- Building python bindings: OFF
-- Building matlab bindings: ON
-- Building CUDA library: OFF
-- Using OpenMP support: ON
-- Using MPI support: OFF
-- Configuring done
CMake Error at src/cpp/CMakeLists.txt:86 (add_library):
  No SOURCES given to target: flann


CMake Error at src/cpp/CMakeLists.txt:32 (add_library):
  No SOURCES given to target: flann_cpp


-- Build files have been written to: /tmp/flann-20181026-5688-uvxgcv/flann-1.9.1

READ THIS: https://github.com/Linuxbrew/brew/wiki/troubleshooting
~~~

-----
