### PR TITLE
Make Emacs depend on libxml2

### DIFF
--- a/Formula/emacs.rb
+++ b/Formula/emacs.rb
@@ -40,7 +40,10 @@ class Emacs < Formula
   depends_on "imagemagick@6" => :optional
   depends_on "librsvg" => :optional
   depends_on "mailutils" => :optional
-  depends_on "ncurses" unless OS.mac?
+  unless OS.mac?
+    depends_on "libxml2"
+    depends_on "ncurses"
+  end
 
   def install
     args = %W[


### PR DESCRIPTION
This fixes build errors related to libxml2 - similar but not identical
to #9995.

- [X] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [X] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----