### PR TITLE
 llvm@6: Fix build for Linuxbrew

### DIFF
--- a/Formula/llvm@6.rb
+++ b/Formula/llvm@6.rb
@@ -17,7 +17,7 @@ class LlvmAT6 < Formula
   # Clang cannot find system headers if Xcode CLT is not installed
   pour_bottle? do
     reason "The bottle needs the Xcode CLT to be installed."
-    satisfy { !OS.mac || MacOS::CLT.installed? }
+    satisfy { !OS.mac? || MacOS::CLT.installed? }
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
Fixes an issue I was seeing: `Error: undefined method 'mac' for OS:Module` in `homebrew-core/Formula/llvm@6.rb:20`

See:
* https://github.com/Linuxbrew/homebrew-core/pull/7037/commits/4eeb673531977e91ceaab8e4f63c4e5a759b8905
* #10012
* #7037
* https://github.com/Linuxbrew/brew/issues/675

- [X] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
