### PR TITLE
terraform-docs: build linux-amd64

### DIFF
--- a/Formula/terraform-docs.rb
+++ b/Formula/terraform-docs.rb
@@ -20,8 +20,8 @@ class TerraformDocs < Formula
     dir.install buildpath.children
 
     cd dir do
-      system "make", "build-darwin-amd64"
-      bin.install "bin/darwin-amd64/terraform-docs"
+      system "make", "build-linux-amd64"
+      bin.install "bin/linux-amd64/terraform-docs"
       prefix.install_metafiles
     end
   end

--- a/Formula/terraform-docs.rb
+++ b/Formula/terraform-docs.rb
@@ -9,7 +9,6 @@ class TerraformDocs < Formula
     sha256 "b41eeb6f997c60a93bc8ec9bf6ad8206561f98b3d2bd464a03b388dcdf1c4676" => :mojave
     sha256 "9ad7cf9b7bfe86ec62e72dc337bf020c13d48a1f97345988d3f8095ba4a6ec0b" => :high_sierra
     sha256 "5c93638483229ba886dbd760b05f29754c3845ac9a839fc2760bdadae5d7ecd4" => :sierra
-    sha256 "245f5114fd7113c4db62edfdc88f489111e7391d8a298826acca23e1fd317019" => :x86_64_linux
   end
 
   depends_on "go" => :build
@@ -20,8 +19,8 @@ class TerraformDocs < Formula
     dir.install buildpath.children
 
     cd dir do
-      system "make", "build-linux-amd64"
-      bin.install "bin/linux-amd64/terraform-docs"
+      system "make", "build-#{OS.mac? ? "darwin" : "linux"}-amd64"
+      bin.install "bin/#{OS.mac? ? "darwin" : "linux"}-amd64/terraform-docs"
       prefix.install_metafiles
     end
   end

--- a/Formula/terraform-docs.rb
+++ b/Formula/terraform-docs.rb
@@ -3,6 +3,7 @@ class TerraformDocs < Formula
   homepage "https://github.com/segmentio/terraform-docs"
   url "https://github.com/segmentio/terraform-docs/archive/v0.5.0.tar.gz"
   sha256 "310f4b13585d6ae59687bf20763af5e27930dd30673af24b7297d5fe1fe9df22"
+  revision 1 unless OS.mac?
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
Currently terraform-docs is getting compiled as `darwin-amd64`, which results in a non-working binary on Linux. Just a simple change to `linux-amd64` to make it work.

----

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
```
$ brew install --build-from-source terraform-docs.rb
==> Installing terraform-docs
==> Downloading https://github.com/segmentio/terraform-docs/archive/v0.5.0.tar.gz
==> Downloading from https://codeload.github.com/segmentio/terraform-docs/tar.gz/v0.5.0
######################################################################## 100.0%
==> make build-linux-amd64
🍺  /home/dgillies/.linuxbrew/Cellar/terraform-docs/0.5.0: 7 files, 3.4MB, built in 4 seconds
$ terraform-docs --version
0.5.0
```

- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
