### PR TITLE
autoconf & automake: Depend on perl

### DIFF
--- a/Formula/autoconf.rb
+++ b/Formula/autoconf.rb
@@ -22,7 +22,9 @@ class Autoconf < Formula
   depends_on "m4" unless OS.mac?
 
   # For autom4te.
-  depends_on "perl" unless which("perl")
+  # Don't use system perl since autoconf requires Data/Dumper.pm which may not
+  # be installed. https://github.com/Linuxbrew/homebrew-core/issues/7522
+  depends_on "perl" unless OS.mac?
 
   def install
     ENV["PERL"] = "/usr/bin/perl" if OS.mac?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Addresses: https://github.com/Linuxbrew/homebrew-core/issues/7522

brew audit log:
```
❯ brew audit --strict autoconf
autoconf:
  * C: 22: col 26: Don't use OS.mac?; Homebrew/core only supports macOS
  * C: 27: col 38: Don't use OS.mac?; Homebrew/core only supports macOS
  * C: 30: col 38: Don't use OS.mac?; Homebrew/core only supports macOS
  * Incorrect file permissions (664): chmod 644 /devtools/linuxbrew/Library/Taps/homebrew/homebrew-core/Formula/autoconf.rb
Error: 4 problems in 1 formula detected

❯ brew audit --strict automake
automake:
  * C: 21: col 38: Don't use OS.mac?; Homebrew/core only supports macOS
  * C: 31: col 38: Don't use OS.mac?; Homebrew/core only supports macOS
  * Incorrect file permissions (664): chmod 644 /devtools/linuxbrew/Library/Taps/homebrew/homebrew-core/Formula/automake.rb
Error: 3 problems in 1 formula detected
```

I'm guessing these errors are ok?