### PR TITLE
version up vtk 8.1.2

### DIFF
--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -1,9 +1,8 @@
 class Vtk < Formula
   desc "Toolkit for 3D computer graphics, image processing, and visualization"
   homepage "https://www.vtk.org/"
-  url "https://www.vtk.org/files/release/8.1/VTK-8.1.1.tar.gz"
-  sha256 "71a09b4340f0a9c58559fe946dc745ab68a866cf20636a41d97b6046cb736324"
-  revision 2
+  url "https://www.vtk.org/files/release/8.1/VTK-8.1.2.tar.gz"
+  sha256 "0995fb36857dd76ccfb8bb07350c214d9f9099e80b1e66b4a8909311f24ff0db"
   head "https://github.com/Kitware/VTK.git"
 
   bottle do


### PR DESCRIPTION
8.1.1 has some problem when

```
brew install vtk --with-python --without-python@2
```
[https://gitlab.kitware.com/vtk/vtk/issues/17350](https://gitlab.kitware.com/vtk/vtk/issues/17350)

So vtk should be updated to 8.1.2.

- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----