### PR TITLE
libidl: Add missing dependencies flex and bison

### DIFF
--- a/Formula/libidl.rb
+++ b/Formula/libidl.rb
@@ -19,6 +19,10 @@ class Libidl < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "glib"
+  unless OS.mac?
+    depends_on "bison" => :build
+    depends_on "flex" => :build
+  end
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

This fixes error in configure (and similar error for yacc):

Last 15 lines from /home/aznb/.cache/Homebrew/Logs/libidl/01.configure:
checking whether we are using the GNU C compiler... (cached) yes
checking whether gcc-5 accepts -g... (cached) yes
checking for gcc-5 option to accept ISO C89... (cached) none needed
checking dependency style of gcc-5... (cached) none
checking how to run the C preprocessor... gcc-5 -E
checking if C preprocessor likes IDL... yes
checking if C preprocessor can read from stdin... yes
checking for flex... no
checking for lex... no
configure: error: flex is required to create the libIDL scanner 


-----