### PR TITLE
ddd: fix compilation error: 'EOF' was not declared in this scope

### DIFF
--- a/Formula/ddd.rb
+++ b/Formula/ddd.rb
@@ -15,7 +15,11 @@ class Ddd < Formula
   end
 
   depends_on "openmotif"
-  depends_on :x11
+  if OS.mac?
+    depends_on :x11
+  else
+    depends_on "linuxbrew/xorg/xorg"
+  end
 
   # Needed for OSX 10.9 DP6 build failure:
   # https://savannah.gnu.org/patch/?8178
@@ -40,6 +44,12 @@ class Ddd < Formula
   end
 
   def install
+    unless OS.mac?
+      # Patch to fix compilation error
+      # https://savannah.gnu.org/bugs/?33960
+      inreplace "ddd/strclass.C", "#include <stdlib.h>", "#include <stdlib.h>\n#include <cstdio>"
+    end
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--enable-builtin-app-defaults",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

This fixes compilation error reported here: https://savannah.gnu.org/bugs/?33960

-----