### PR TITLE
dcmtk: add dependency on libxml2, enable shared library support

### DIFF
--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -4,13 +4,13 @@ class Dcmtk < Formula
   url "https://dicom.offis.de/download/dcmtk/dcmtk363/dcmtk-3.6.3.tar.gz"
   sha256 "63c373929f610653f10cbb8218ec643804eec6f842d3889d2b46a227da1ed530"
   head "https://git.dcmtk.org/dcmtk.git"
+  revision 1 unless OS.mac?
 
   bottle do
     sha256 "cf1f1557cbb1842de688bc31128a98e059cddad80e9265d1244129f838ae60d8" => :mojave
     sha256 "ebc1492ba0b008c2d84e84cce1be2da9eb9210ffa8809bcfc710a0bcf35d5575" => :high_sierra
     sha256 "c7771b2deb50e919f2b332d532f7f81bd67331a2350aea85f7f61658a70b5b15" => :sierra
     sha256 "586903834cdc7bbc4ffc7adb5478b63fb80df1f95b1a631a8b41d5b54bbc275f" => :el_capitan
-    sha256 "208bac2dbdfee378c5e786100498cd6e7836761315657aa790ff04a9c024279d" => :x86_64_linux
   end
 
   depends_on "cmake" => :build

--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -16,12 +16,12 @@ class Dcmtk < Formula
   depends_on "cmake" => :build
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on "libxml2"
+  depends_on "libxml2" unless OS.mac?)
   depends_on "openssl"
 
   def install
     mkdir "build" do
-      system "cmake", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args, ".."
+      system "cmake", ("-DBUILD_SHARED_LIBS=ON" unless OS.mac?), *std_cmake_args, ".."
       system "make", "install"
     end
   end

--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -16,11 +16,12 @@ class Dcmtk < Formula
   depends_on "cmake" => :build
   depends_on "libpng"
   depends_on "libtiff"
+  depends_on "libxml2"
   depends_on "openssl"
 
   def install
     mkdir "build" do
-      system "cmake", *std_cmake_args, ".."
+      system "cmake", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args, ".."
       system "make", "install"
     end
   end


### PR DESCRIPTION
- [x ] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

It fixes this issue 
https://github.com/Linuxbrew/homebrew-core/issues/11103
However, it requires also a rebuild from source of libtiff
  brew reinstall --build-from-source libtiff 

the the gist-log is here
https://gist.github.com/schloegl/0bb90b2984c47788459eba1bc68f13b6

-----
