### PR TITLE
Prodigal patch

### DIFF
--- a/Formula/prodigal.rb
+++ b/Formula/prodigal.rb
@@ -3,6 +3,7 @@ class Prodigal < Formula
   homepage "https://github.com/hyattpd/Prodigal"
   url "https://github.com/hyattpd/Prodigal/archive/v2.6.3.tar.gz"
   sha256 "89094ad4bff5a8a8732d899f31cec350f5a4c27bcbdd12663f87c9d1f0ec599f"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -10,9 +11,18 @@ class Prodigal < Formula
     sha256 "c120fed8e29bb3b1a4ff69d5ca05e051a0fe3822784b3d585e142da3452d1ac1" => :high_sierra
     sha256 "a27fe5316181d4826e5aa5291d0fc1b1a7087c32c7b4e6aedabf1209d5a8ac36" => :sierra
     sha256 "70b432e3d3da1f4089680b06c0745b7dac3611f05d8ec9440faa918bc82d6fe5" => :el_capitan
-    sha256 "8ed04aa4b59962ddfeb1ff3a4bd58355071f7a1a33f7614f28425aaed39873c2" => :x86_64_linux
   end
 
+  # Prodigal will have incorrect output if compiled with certain compilers.
+  # This will be fixed in the next release. Also see:
+  # https://github.com/hyattpd/Prodigal/issues/34
+  # https://github.com/hyattpd/Prodigal/issues/41
+  unless OS.mac?
+    patch do
+      url "https://github.com/hyattpd/Prodigal/pull/35.patch?full_index=1"
+      sha256 "fd292c0a98412a7f2ed06d86e0e3f96a9ad698f6772990321ad56985323b99a6"
+    end
+  end
   def install
     system "make", "install", "INSTALLDIR=#{bin}"
   end


### PR DESCRIPTION
    Add patch to prodigal and add head to prodigal
    
    Prodigal will have incorrect output if installed with a wrong compiler.
    Also see:
    https://github.com/hyattpd/Prodigal/issues/34
    https://github.com/hyattpd/Prodigal/issues/41

---

brew audit --strict --online said the github link was wrong. So I don't know if that should be fixed? sjackman gave me that link, so he should know what you he is doing?

---

A few other questions about linuxbrew in general:

Why doesn't linuxbrew check if it already has the dependency. Sometimes it even installs its own "less", because it is an dependency of something. Can't this be configured to not do that? Except from manually doing checking dependencies off course. 

Why aren't formula shared among homebrew and linuxbrew? I believe taps are shared, but why maintain the core formula in different repo's?

Do you see any future in future in linuxbrew? It seems like it can do the same as snap: Installing stuff that is too old in the apt repo's. I prefer compiling it then, than to use snap. 

Thanks

---

- [ x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
