### PR TITLE
qwt: Fix build for Linuxbrew

### DIFF
--- a/Formula/qwt.rb
+++ b/Formula/qwt.rb
@@ -27,11 +27,13 @@ class Qwt < Formula
              "\\1/lib/qt/\\2"
     end
 
-    args = ["-config", "release", "-spec"]
-    if ENV.compiler == :clang
-      args << "macx-clang"
-    elsif OS.mac?
-      args << "macx-g++"
+    args = ["-config", "release"]
+    if OS.mac?
+      if ENV.compiler == :clang
+        args.push *["--spec", "macx-clang"]
+      else
+        args.push *["--spec", "macx-g++"]
+      end
     end
 
     system "qmake", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests]
It was **Closed**. Something unsatisfied Travis / UbuntuTrusty.
https://github.com/Linuxbrew/homebrew-core/pull/1148
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`
```
Warning: qwt dependency gettext was built with a different C++ standard
library (libstdc++ from gcc-5). This may cause problems at runtime.
🍺  /home/linuxbrew/.linuxbrew/Cellar/qwt/6.1.3_4: 1,670 files, 19MB, built in 4 minutes 7 seconds
```
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [x] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.
**before changes:** [gist](https://gist.github.com/JuPlutonic/5a7e9896c14431ba884c7ba9cdc0d405)
-----
