### PR TITLE
gcc: re-add make command. fixes merge issue introduced in de0c3a2.

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -187,7 +187,7 @@ class Gcc < Formula
       # Use -headerpad_max_install_names in the build,
       # otherwise updated load commands won't fit in the Mach-O header.
       # This is needed because `gcc` avoids the superenv shim.
-      system "make", "install"
+      system "make", "BOOT_LDFLAGS=-Wl,-headerpad_max_install_names"
       system "make", OS.mac? ? "install" : "install-strip"
 
       if build.with?("fortran") || build.with?("all-languages")


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Linuxbrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Linuxbrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----

Fixes #11661.

This issue was recreated in a container with only the minimum native tools and no brew formulae installed.
* `brew test` isn't possible because I don't have `glibc` yet. Installing `gcc` from source is a prereq for installing `glibc` (also from source) in CentOS 6.
* `brew audit` doesn't work because of SSL verification issues, which should be fixed after I install curl. The error output is copied from #11661 below.

```
==> Downloading https://ftp.gnu.org/gnu/gcc/gcc-5.5.0/gcc-5.5.0.tar.xz
Already downloaded: /home/test/.cache/Homebrew/downloads/62d8cc20018aa926380222fa7098af4384ca68c3ebdabe0806f2cd801ea0d075--gcc-5.5.0.tar.xz
==> ../configure --with-isl=/hosting/tools/opt/isl@0.18 --with-bugurl=https://github.com/Linuxbrew/homebrew-core/issues -
==> make install
Last 15 lines from /home/test/.cache/Homebrew/Logs/gcc/02.make:
install

make[1]: Entering directory `/tmp/gcc-20190213-40183-1yzuwkt/gcc-5.5.0/build'
/bin/sh ../mkinstalldirs /hosting/tools/Cellar/gcc/5.5.0_4 /hosting/tools/Cellar/gcc/5.5.0_4
/bin/sh: line 3: cd: ./lto-plugin: No such file or directory
make[1]: *** [install-lto-plugin] Error 1
make[1]: *** Waiting for unfinished jobs....
/bin/sh: line 3: cd: ./intl: No such file or directory
make[1]: *** [install-intl] Error 1
/bin/sh: line 3: cd: ./libbacktrace: No such file or directory
make[1]: *** [install-libbacktrace] Error 1
/bin/sh: line 3: cd: ./fixincludes: No such file or directory
make[1]: *** [install-fixincludes] Error 1
make[1]: *** wait: No child processes.  Stop.
make: *** [install] Error 2
```
